### PR TITLE
Change input elements activation on AppComponentBase to ngAfterViewChecked

### DIFF
--- a/angular/src/shared/app-component-base.ts
+++ b/angular/src/shared/app-component-base.ts
@@ -35,7 +35,7 @@ export abstract class AppComponentBase {
         this.domNode = injector.get(ElementRef).nativeElement;
     }
     
-    ngAfterViewInit(): void {
+    ngAfterViewChecked(): void {
         ($ as any).AdminBSB.input.activate($(this.domNode));
     }
 


### PR DESCRIPTION


This becomes necessary when working with *ngIf input elements. Using ngAfterViewInit will not activate elements where *ngIf directives initiates as false.