### PR TITLE
Standardise lowercase 'post' using asp.net default

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Account/Login.cshtml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Account/Login.cshtml
@@ -25,7 +25,7 @@
 }
 <div class="card">
     <div class="body">
-        <form id="LoginForm" method="post" asp-action="Login">
+        <form id="LoginForm" asp-action="Login" method="post">
             <input type="hidden" name="returnUrl" value="@Model.ReturnUrl" />
             <input type="hidden" name="returnUrlHash" />
             <h4 class="text-center">@L("LogIn")</h4>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Account/Login.cshtml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Account/Login.cshtml
@@ -25,7 +25,7 @@
 }
 <div class="card">
     <div class="body">
-        <form id="LoginForm" method="POST" asp-action="Login">
+        <form id="LoginForm" method="post" asp-action="Login">
             <input type="hidden" name="returnUrl" value="@Model.ReturnUrl" />
             <input type="hidden" name="returnUrlHash" />
             <h4 class="text-center">@L("LogIn")</h4>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Account/Register.cshtml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Account/Register.cshtml
@@ -24,7 +24,7 @@
 }
 <div class="card">
     <div class="body">
-        <form id="RegisterForm" asp-action="Register" method="POST">
+        <form id="RegisterForm" asp-action="Register" method="post">
             <h4 class="text-center">@L("Register")</h4>
 
             @if (@ViewBag.ErrorMessage != null)


### PR DESCRIPTION
Current lowercase usage:
- `<form asp-action="ExternalLogin" method="post">` in [Login.cshtml#L91](https://github.com/aspnetboilerplate/module-zero-core-template/blob/cdd334959c650568e556cd0b40cfe00595250c81/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Account/Login.cshtml#L91)

Reasons for choosing lowercase:
- IntelliSense suggests `post`
- ASP.NET defaults to `post`

Other considerations:
- HTML5 is case-*in*sensitive
- XHTML requires lowercase
- HTTP sends uppercase regardless