### PR TITLE
Add swagger security definitions and requirements

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/SecurityRequirementsOperationFilter.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/SecurityRequirementsOperationFilter.cs
@@ -1,0 +1,48 @@
+﻿using Abp.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AbpCompanyName.AbpProjectName.Web.Host.Startup
+{
+    public class SecurityRequirementsOperationFilter : IOperationFilter
+    {
+        private readonly IOptions<AuthorizationOptions> authorizationOptions;
+
+        public SecurityRequirementsOperationFilter(IOptions<AuthorizationOptions> authorizationOptions)
+        {
+            this.authorizationOptions = authorizationOptions;
+        }
+
+        public void Apply(Operation operation, OperationFilterContext context)
+        {
+            var controllerPermissions = context.ApiDescription.ControllerAttributes()
+                .OfType<AbpAuthorizeAttribute>()
+                .Select(attr => attr.Permissions);
+
+            var actionPermissions = context.ApiDescription.ActionAttributes()
+                .OfType<AbpAuthorizeAttribute>()
+                .Select(attr => attr.Permissions);
+
+            var permissions = controllerPermissions.Union(actionPermissions).Distinct()
+                .SelectMany(p => p);
+
+            if (permissions.Any())
+            {
+                operation.Responses.Add("401", new Response { Description = "Unauthorized" });
+                operation.Responses.Add("403", new Response { Description = "Forbidden" });
+
+                operation.Security = new List<IDictionary<string, IEnumerable<string>>>
+                {
+                    new Dictionary<string, IEnumerable<string>>
+                    {
+                        { "bearerAuth", permissions }
+                    }
+                };
+            }
+        }
+    }
+}

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs
@@ -64,6 +64,8 @@ namespace AbpCompanyName.AbpProjectName.Web.Host.Startup
             {
                 options.SwaggerDoc("v1", new Info { Title = "AbpProjectName API", Version = "v1" });
                 options.DocInclusionPredicate((docName, description) => true);
+
+                // Define the BearerAuth scheme that's in use
                 options.AddSecurityDefinition("bearerAuth", new ApiKeyScheme()
                 {
                     Description = "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
@@ -71,6 +73,8 @@ namespace AbpCompanyName.AbpProjectName.Web.Host.Startup
                     In = "header",
                     Type = "apiKey"
                 });
+                // Assign scope requirements to operations based on AuthorizeAttribute
+                options.OperationFilter<SecurityRequirementsOperationFilter>();
             });
 
             //Configure Abp and Dependency Injection

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs
@@ -64,6 +64,13 @@ namespace AbpCompanyName.AbpProjectName.Web.Host.Startup
             {
                 options.SwaggerDoc("v1", new Info { Title = "AbpProjectName API", Version = "v1" });
                 options.DocInclusionPredicate((docName, description) => true);
+                options.AddSecurityDefinition("bearerAuth", new ApiKeyScheme()
+                {
+                    Description = "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
+                    Name = "Authorization",
+                    In = "header",
+                    Type = "apiKey"
+                });
             });
 
             //Configure Abp and Dependency Injection


### PR DESCRIPTION
Fixes aspnetboilerplate/aspnetboilerplate#2302

- [x] **Security definitions**: Authorize button. Generated clients automatically send bearer token in header.
- [x] **Security requirements**:
  - [x] i. Mention for each call whether it needs authentication
  - [x] ii. and if so, [which *permissions* are required](https://github.com/aspnetboilerplate/module-zero-core-template/pull/108/commits/09583d1bf14ea1c40dea32bd72f34316f28afca3#diff-0632263b3d556f3ecf56f8691e928a1aR42).
This doesn't seem to be supported for `apiKey` or `bearerAuth`, only *scopes* in `oauth2`.

<img width="728" alt="Authorize button" src="https://user-images.githubusercontent.com/14091939/29727562-0beae0ea-8a07-11e7-97dc-8252a7022884.png" title="Authorize button" />
<img width="407" alt="Authorize window" src="https://user-images.githubusercontent.com/14091939/29728277-dc61642c-8a09-11e7-829b-575083a443a5.png" title="Authorize window" />
<img width="733" alt="Needs authentication" src="https://user-images.githubusercontent.com/14091939/29781018-5c702e04-8c4a-11e7-908a-b8e73590b4d4.png" title="Needs authentication" />

References:
https://github.com/domaindrivendev/Swashbuckle.AspNetCore#add-security-definitions-and-requirements