### PR TITLE
Add missing localization used in various classes

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Application/Roles/RoleAppService.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Application/Roles/RoleAppService.cs
@@ -75,7 +75,7 @@ namespace AbpCompanyName.AbpProjectName.Roles
             var role = await _roleManager.FindByIdAsync(input.Id.ToString());
             if (role.IsStatic)
             {
-                throw new UserFriendlyException("CannotDeleteAStaticRole");
+                throw new UserFriendlyException(L("CanNotDeleteStaticRole"));
             }
 
             var users = await _userManager.GetUsersInRoleAsync(role.NormalizedName);

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Localization/SourceFiles/AbpProjectName.xml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Localization/SourceFiles/AbpProjectName.xml
@@ -81,5 +81,7 @@
     <text name="EditRole">Edit role</text>
     <text name="EditTenant">Edit tenant</text>
     <text name="EditUser">Edit user</text>
+    <text name="TenantIdIsNotActive{0}">TenantId {0} is not active</text>
+    <text name="UnknownTenantId{0}">Unknown tenantId {0}</text>
   </texts>
 </localizationDictionary>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Localization/SourceFiles/AbpProjectName.xml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Localization/SourceFiles/AbpProjectName.xml
@@ -72,7 +72,7 @@
     <text name="Edit">Edit</text>
     <text name="Delete">Delete</text>
 
-    <text name="CreateNewRole">Create New Role</text>
+    <text name="CreateNewRole">Create new role</text>
     <text name="RoleName">Role Name</text>
     <text name="Actions">Actions</text>
 

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Localization/SourceFiles/AbpProjectName.xml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Localization/SourceFiles/AbpProjectName.xml
@@ -77,5 +77,9 @@
     <text name="Actions">Actions</text>
 
     <text name="CouldNotCompleteLoginOperation">Could not complete login operation. Please try again later.</text>
+
+    <text name="EditRole">Edit role</text>
+    <text name="EditTenant">Edit tenant</text>
+    <text name="EditUser">Edit user</text>
   </texts>
 </localizationDictionary>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Localization/SourceFiles/AbpProjectName.xml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Localization/SourceFiles/AbpProjectName.xml
@@ -78,6 +78,7 @@
 
     <text name="CouldNotCompleteLoginOperation">Could not complete login operation. Please try again later.</text>
 
+    <text name="CouldNotValidateExternalUser">Could not validate external user</text>
     <text name="EditRole">Edit role</text>
     <text name="EditTenant">Edit tenant</text>
     <text name="EditUser">Edit user</text>


### PR DESCRIPTION
1. Add missing localization used in edit modals: e0ea3ff

https://github.com/aspnetboilerplate/module-zero-core-template/blob/d98b80c6d42e94d2fbb0a77a58fbecc85ea03ca7/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Roles/_EditRoleModal.cshtml#L6

https://github.com/aspnetboilerplate/module-zero-core-template/blob/d98b80c6d42e94d2fbb0a77a58fbecc85ea03ca7/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Tenants/_EditTenantModal.cshtml#L8

https://github.com/aspnetboilerplate/module-zero-core-template/blob/d98b80c6d42e94d2fbb0a77a58fbecc85ea03ca7/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Users/_EditUserModal.cshtml#L6