### PR TITLE
Fix checkbox not working when edit role permission

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Roles/Index.cshtml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Roles/Index.cshtml
@@ -115,8 +115,8 @@
                             @foreach (var permission in Model.Permissions)
                             {
                                 <div class="col-sm-6">
-                                    <input type="checkbox" name="permission" value="@permission.Name" class="filled-in" id="@string.Format("permission-{0}",permission.Name)" checked="checked" />
-                                    <label for="@string.Format("permission-{0}",permission.Name)">@permission.DisplayName</label>
+                                    <input type="checkbox" name="permission" value="@permission.Name" class="filled-in" id="permission-@permission.Name" checked="checked" />
+                                    <label for="permission-@permission.Name">@permission.DisplayName</label>
                                 </div>
                             }
                         </div>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Roles/Index.cshtml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Roles/Index.cshtml
@@ -115,8 +115,8 @@
                             @foreach (var permission in Model.Permissions)
                             {
                                 <div class="col-sm-6">
-                                    <input type="checkbox" name="permission" value="@permission.Name" class="filled-in" id="@string.Format("permission{0}",permission.Name)" checked="checked" />
-                                    <label for="@string.Format("permission{0}",permission.Name)">@permission.DisplayName</label>
+                                    <input type="checkbox" name="permission" value="@permission.Name" class="filled-in" id="@string.Format("permission-{0}",permission.Name)" checked="checked" />
+                                    <label for="@string.Format("permission-{0}",permission.Name)">@permission.DisplayName</label>
                                 </div>
                             }
                         </div>


### PR DESCRIPTION
# Issue

This is due to the `label for="{id}"` in

https://github.com/aspnetboilerplate/module-zero-core-template/blob/fbcf9eb862500e11a3f56f16f2e457634740e14d/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Roles/_EditRoleModal.cshtml#L51-L52

referencing the same `id` in

https://github.com/aspnetboilerplate/module-zero-core-template/blob/fbcf9eb862500e11a3f56f16f2e457634740e14d/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Roles/Index.cshtml#L118-L119

# Fix

I decided to modify `Roles/Index.cshtml` instead of `_EditRoleModal.cshtml`

```html
<input type="checkbox" name="permission" value="@permission.Name" class="filled-in" id="permission-@permission.Name" checked="checked" />
<label for="permission-@permission.Name">@permission.DisplayName</label>
```

to be consistent with `Users/Index.cshtml`

https://github.com/aspnetboilerplate/module-zero-core-template/blob/fbcf9eb862500e11a3f56f16f2e457634740e14d/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Users/Index.cshtml#L163-L164