### PR TITLE
added web-animations-js to package.json

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -65,6 +65,7 @@
         "sweetalert": "^1.1.3",
         "toastr": "^2.1.2",
         "ts-helpers": "^1.1.2",
+        "web-animations-js": "^2.3.1",
         "zone.js": "0.8.17"
     },
     "devDependencies": {

--- a/angular/src/polyfills.ts
+++ b/angular/src/polyfills.ts
@@ -37,7 +37,7 @@ import 'core-js/es6/set';
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /** IE10 and IE11 requires the following to support `@angular/animation`. */
-//import 'web-animations-js';  // Run `npm install --save web-animations-js`.
+import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
 
 /** Evergreen browsers require these. **/


### PR DESCRIPTION
When generating a template, I was unable to run the angular project. It complained about web-animations-js.

From this commit a week ago, it appears this was added to the polyfill.ts but it wasn't added to the packages, so it wasn't being brought in.

https://github.com/aspnetboilerplate/module-zero-core-template/commit/3c0856bb5e6c19cbcf7baf17b95fd1b72b872960