### PR TITLE
the key for clientAuthorizations.add must be the same as the one of the SecurityDefinition

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/wwwroot/swagger/ui/on-complete.js
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/wwwroot/swagger/ui/on-complete.js
@@ -11,7 +11,7 @@ var abp = abp || {};
             return false;
         }
         var cookieAuth = new SwaggerClient.ApiKeyAuthorization(abp.auth.tokenHeaderName, 'Bearer ' + authToken, 'header');
-        swaggerUi.api.clientAuthorizations.add(abp.auth.tokenHeaderName, cookieAuth);
+        swaggerUi.api.clientAuthorizations.add('bearerAuth', cookieAuth);
         return true;
     }
 


### PR DESCRIPTION
see securitydefinition defined in startup.cs 

https://github.com/aspnetboilerplate/module-zero-core-template/blob/8eb2944430aa814557112c21769c70231f69b911/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs#L72

see also https://github.com/swagger-api/swagger-ui/issues/1244#issuecomment-245638234