### PR TITLE
Remove authSchema parameter passed as expectedXsrf

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Controllers/AccountController.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Controllers/AccountController.cs
@@ -271,8 +271,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Controllers
                 "Account",
                 new
                 {
-                    ReturnUrl = returnUrl,
-                    authSchema = provider
+                    ReturnUrl = returnUrl
                 });
 
             return Challenge(
@@ -287,7 +286,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Controllers
         }
 
         [UnitOfWork]
-        public virtual async Task<ActionResult> ExternalLoginCallback(string returnUrl, string authSchema, string remoteError = null)
+        public virtual async Task<ActionResult> ExternalLoginCallback(string returnUrl, string remoteError = null)
         {
             returnUrl = NormalizeReturnUrl(returnUrl);
             
@@ -297,7 +296,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Controllers
                 throw new UserFriendlyException(L("CouldNotCompleteLoginOperation"));
             }
 
-            var externalLoginInfo = await _signInManager.GetExternalLoginInfoAsync(authSchema);
+            var externalLoginInfo = await _signInManager.GetExternalLoginInfoAsync();
             if (externalLoginInfo == null)
             {
                 Logger.Warn("Could not get information from external login.");


### PR DESCRIPTION
Fixes https://forum.aspnetboilerplate.com/viewtopic.php?p=23831

Actual parameter in [Microsoft.AspNetCore.Identity/SignInManager.cs#L549-L588](https://github.com/aspnet/Identity/blob/eb3ff7fc32dbfff65a1ba6dfdca16487e0f6fc41/src/Microsoft.AspNetCore.Identity/SignInManager.cs#L549-L588):
```c#
/// <param name="expectedXsrf">Flag indication whether a Cross Site Request Forgery token was expected in the current request.</param>
/// <returns>...</returns>
public virtual async Task<ExternalLoginInfo> GetExternalLoginInfoAsync(string expectedXsrf = null)
```