### PR TITLE
Remove confirmation for exit with no verification

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/Program.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/Program.cs
@@ -29,8 +29,11 @@ namespace AbpCompanyName.AbpProjectName.Migrator
                     migrateExecuter.Object.Run(_skipConnVerification);
                 }
 
-                Console.WriteLine("Press ENTER to exit...");
-                Console.ReadLine();
+                if (!_skipConnVerification)
+                {
+                    Console.WriteLine("Press ENTER to exit...");
+                    Console.ReadLine();
+                }
             }
         }
 


### PR DESCRIPTION
In order to use Migrator in Continuous Integration pipelines (which runs unattended), it should have a fully silent mode. So I suggest making the wait for exit confirmation at the end optional. I reused `_skipConnVerification` since no backward compatibility required for ABP templates.  

BTW I doubt `_skipConnVerification` was correctly named in the first place, so feel free to alter the PR (add another optional parameter defaulting to wait for confirmation) to give the same effect.