### PR TITLE
Fixed login page styles

### DIFF
--- a/angular/src/account/account.component.less
+++ b/angular/src/account/account.component.less
@@ -11,9 +11,3 @@
         cursor: pointer;
     }
 }
-
-div#LoginArea {
-    margin-top: 0px !important;
-    max-width: 400px;
-    margin: 120px auto 10px auto;
-}

--- a/angular/src/account/login/login.component.html
+++ b/angular/src/account/login/login.component.html
@@ -1,4 +1,4 @@
-﻿<div class="card" [@routerTransition]>
+﻿<div class="card" id="LoginArea" [@routerTransition]>
     <div #cardBody class="body">
         <form #loginForm="ngForm" id="LoginForm" method="post" novalidate (ngSubmit)="login()">
             <h4 class="text-center">{{l("LogIn")}}</h4>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Account/Login.cshtml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Account/Login.cshtml
@@ -23,7 +23,7 @@
         <script src="~/view-resources/Views/Account/Login.min.js" asp-append-version="true"></script>
     </environment>
 }
-<div class="card">
+<div class="card" id="﻿LoginArea">
     <div class="body">
         <form id="LoginForm" asp-action="Login" method="post">
             <input type="hidden" name="returnUrl" value="@Model.ReturnUrl" />

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/wwwroot/view-resources/Views/Account/Login.css
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/wwwroot/view-resources/Views/Account/Login.css
@@ -1,8 +1,4 @@
-﻿#LoginArea {
-  max-width: 400px;
-  margin: 120px auto 10px auto;
-}
-.social-icons {
+﻿.social-icons {
   padding-left: 0px;
 }
 .social-icons a.btn-sm {

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/wwwroot/view-resources/Views/Account/Login.less
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/wwwroot/view-resources/Views/Account/Login.less
@@ -1,9 +1,4 @@
-﻿#LoginArea {
-    max-width: 400px;
-    margin: 120px auto 10px auto;
-}
-
-.social-icons {
+﻿.social-icons {
     padding-left: 0px;
 
     a.btn-sm {


### PR DESCRIPTION
In [login.js](https://github.com/aspnetboilerplate/module-zero-core-template/blob/master/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/wwwroot/view-resources/Views/Account/Login.js#L26), `#LoginArea` is used as the element for busy indicator.

However, after BSB Admin theme is implemented, `#LoginArea` was removed.

To keep the behavior of setting busy indicator for login, I would suggest removing the styles apply to `#LoginArea` since it's replace by `card` in BSB Admin, and adding back the element id for login area