### PR TITLE
Add exit code to migrator to signify program's exit status

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/MultiTenantMigrateExecuter.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/MultiTenantMigrateExecuter.cs
@@ -34,13 +34,13 @@ namespace AbpCompanyName.AbpProjectName.Migrator
             _connectionStringResolver = connectionStringResolver;
         }
 
-        public void Run(bool skipConnVerification)
+        public bool Run(bool skipConnVerification)
         {
             var hostConnStr = _connectionStringResolver.GetNameOrConnectionString(new ConnectionStringResolveArgs(MultiTenancySides.Host));
             if (hostConnStr.IsNullOrWhiteSpace())
             {
                 Log.Write("Configuration file should contain a connection string named 'Default'");
-                return;
+                return false;
             }
 
             Log.Write("Host database: " + ConnectionStringHelper.GetConnectionString(hostConnStr));
@@ -51,7 +51,7 @@ namespace AbpCompanyName.AbpProjectName.Migrator
                 if (!command.IsIn("Y", "y"))
                 {
                     Log.Write("Migration canceled.");
-                    return;
+                    return false;
                 }
             }
 
@@ -66,7 +66,7 @@ namespace AbpCompanyName.AbpProjectName.Migrator
                 Log.Write("An error occured during migration of host database:");
                 Log.Write(ex.ToString());
                 Log.Write("Canceled migrations.");
-                return;
+                return false;
             }
 
             Log.Write("HOST database migration completed.");
@@ -108,6 +108,8 @@ namespace AbpCompanyName.AbpProjectName.Migrator
             }
 
             Log.Write("All databases have been migrated.");
+
+            return true;
         }
     }
 }

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/Program.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/Program.cs
@@ -26,7 +26,11 @@ namespace AbpCompanyName.AbpProjectName.Migrator
 
                 using (var migrateExecuter = bootstrapper.IocManager.ResolveAsDisposable<MultiTenantMigrateExecuter>())
                 {
-                    migrateExecuter.Object.Run(_quietMode);
+                    var migrationSucceeded = migrateExecuter.Object.Run(_quietMode);
+                    // exit clean (with exit code 0) if migration is a success, otherwise exit with code 1
+                    var exitCode = Convert.ToInt32(!migrationSucceeded);
+
+                    Environment.Exit(exitCode);
                 }
 
                 if (!_quietMode)


### PR DESCRIPTION
Using the migrator in CI (Continuous Integration) pipelines where it runs unattended, it is important to know how things went for it, so as to make the build/test fail.

This PR adds migrator the ability to tell whether it run successfully or not by emitting the exit code. Currently, it is always returning 0 to the operating system which makes it infeasible (parsing logs is an option) to tell if something went wrong.