### PR TITLE
Added settings to change Kestrel port when run with dotnet run

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Properties/launchSettings.json
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Properties/launchSettings.json
@@ -21,7 +21,8 @@
       "launchUrl": "http://localhost:21021",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "http://localhost:12021/"
     }
   }
 }


### PR DESCRIPTION
With current template `dotnet run` starts Web.Host application on port 5000 which is inconvenient.
With my change it will start on 21021.
See https://stackoverflow.com/a/49000939/606007 for details.