### PR TITLE
Only send Authorization header if token is present

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/wwwroot/swagger/ui/index.html
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/wwwroot/swagger/ui/index.html
@@ -79,7 +79,8 @@
             configObject.presets = [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset];
             configObject.layout = "StandaloneLayout";
             configObject.requestInterceptor = function (request) {
-                request.headers.Authorization = "Bearer " + abp.auth.getToken();
+                var token = abp.auth.getToken();
+                request.headers.Authorization = token ? "Bearer " + token : null;
                 return request;
             };
             if (!configObject.hasOwnProperty("oauth2RedirectUrl")) {


### PR DESCRIPTION
Previously it would send "Authorization: Bearer null" when no token was present