### PR TITLE
upgrade to abpv3.8.2 Replace unsupported methods of SecurityRequirementsOperationFilter

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/AbpCompanyName.AbpProjectName.Core.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/AbpCompanyName.AbpProjectName.Core.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Abp.AutoMapper" Version="3.8.1" />
-    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="3.8.1" />
+    <PackageReference Include="Abp.AutoMapper" Version="3.8.2" />
+    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="3.8.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/AbpCompanyName.AbpProjectName.Migrator.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/AbpCompanyName.AbpProjectName.Migrator.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Abp.Castle.Log4Net" Version="3.8.1" />
+    <PackageReference Include="Abp.Castle.Log4Net" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Core/AbpCompanyName.AbpProjectName.Web.Core.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Core/AbpCompanyName.AbpProjectName.Web.Core.csproj
@@ -25,11 +25,11 @@
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.5.0" />
-    <PackageReference Include="Abp.AspNetCore" Version="3.8.1" />
-    <PackageReference Include="Abp.ZeroCore" Version="3.8.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="3.0.0" />
+    <PackageReference Include="Abp.AspNetCore" Version="3.8.2" />
+    <PackageReference Include="Abp.ZeroCore" Version="3.8.2" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.2" />
-    <PackageReference Include="Abp.AspNetCore.SignalR" Version="3.8.1" />
+    <PackageReference Include="Abp.AspNetCore.SignalR" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/AbpCompanyName.AbpProjectName.Web.Host.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/AbpCompanyName.AbpProjectName.Web.Host.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
-    <PackageReference Include="Abp.Castle.Log4Net" Version="3.8.1" />
+    <PackageReference Include="Abp.Castle.Log4Net" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/SecurityRequirementsOperationFilter.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/SecurityRequirementsOperationFilter.cs
@@ -10,13 +10,13 @@ namespace AbpCompanyName.AbpProjectName.Web.Host.Startup
     {
         public void Apply(Operation operation, OperationFilterContext context)
         {
-            var actionAttrs = context.ControllerActionDescriptor.MethodInfo.GetCustomAttributes(true).ToList();
+            var actionAttrs = context.MethodInfo.GetCustomAttributes(true).ToList();
             if (actionAttrs.OfType<AbpAllowAnonymousAttribute>().Any())
             {
                 return;
             }
 
-            var controllerAttrs = context.ControllerActionDescriptor.ControllerTypeInfo.GetCustomAttributes(true);
+            var controllerAttrs = context.MethodInfo.DeclaringType.GetCustomAttributes(true);
             var actionAbpAuthorizeAttrs = actionAttrs.OfType<AbpAuthorizeAttribute>().ToList();
 
             if (!actionAbpAuthorizeAttrs.Any() && controllerAttrs.OfType<AbpAllowAnonymousAttribute>().Any())

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/AbpCompanyName.AbpProjectName.Web.Mvc.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/AbpCompanyName.AbpProjectName.Web.Mvc.csproj
@@ -47,9 +47,9 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
-    <PackageReference Include="Abp.HangFire" Version="3.8.1" />
-    <PackageReference Include="Abp.RedisCache" Version="3.8.1" />
-    <PackageReference Include="Abp.Castle.Log4Net" Version="3.8.1" />
+    <PackageReference Include="Abp.HangFire" Version="3.8.2" />
+    <PackageReference Include="Abp.RedisCache" Version="3.8.2" />
+    <PackageReference Include="Abp.Castle.Log4Net" Version="3.8.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="2.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/aspnet-core/test/AbpCompanyName.AbpProjectName.Tests/AbpCompanyName.AbpProjectName.Tests.csproj
+++ b/aspnet-core/test/AbpCompanyName.AbpProjectName.Tests/AbpCompanyName.AbpProjectName.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Abp.TestBase" Version="3.8.1" />
+    <PackageReference Include="Abp.TestBase" Version="3.8.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.1" />
     <PackageReference Include="Castle.Core" Version="4.3.1" />
   </ItemGroup>


### PR DESCRIPTION
upgrade to abpv3.8.2 Replace unsupported methods of SecurityRequirementsOperationFilter