### PR TITLE
Fixed incorrect port number in launch settings

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Properties/launchSettings.json
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Properties/launchSettings.json
@@ -22,7 +22,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:12021/"
+      "applicationUrl": "http://localhost:21021/"
     }
   }
 }


### PR DESCRIPTION
Typo in Web.Host project launch settings configuration is preventing a freshly downloaded Angular/ASP.NET Core startup template to run.