### PR TITLE
Fix swagger endpoint url

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs
@@ -119,7 +119,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Host.Startup
             // Enable middleware to serve swagger-ui assets (HTML, JS, CSS etc.)
             app.UseSwaggerUI(options =>
             {
-                options.SwaggerEndpoint(_appConfiguration["App:ServerRootAddress"] + "/swagger/v1/swagger.json", "AbpProjectName API V1");
+                options.SwaggerEndpoint(_appConfiguration["App:ServerRootAddress"].EnsureEndsWith('/') + "swagger/v1/swagger.json", "AbpProjectName API V1");
                 options.IndexStream = () => Assembly.GetExecutingAssembly()
                     .GetManifestResourceStream("AbpCompanyName.AbpProjectName.Web.Host.wwwroot.swagger.ui.index.html");
             }); // URL: /swagger


### PR DESCRIPTION
To sure swagger endpoint url is formed correctly.

`_appConfiguration[App:ServerRootAddress]` may or may not have url ends with `"/"`