### PR TITLE
Fix casing on App.config to enable linux builds

### DIFF
--- a/angular/AbpCompanyName.AbpProjectName.AngularUI.csproj
+++ b/angular/AbpCompanyName.AbpProjectName.AngularUI.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <Compile Remove="dist" />
-    <None Include="App.config" />
+    <None Include="app.config" />
     <None Update="wwwroot\**\*;web.config">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>


### PR DESCRIPTION
The difference in casing between the file and the
reference in the project file produced errors building
on Azure DevOps on an Ubuntu system.