### PR TITLE
Enable and repair tslint (v5.12.1) support for angular

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -9,7 +9,8 @@
     "hmr": "ng serve --host 0.0.0.0 --port 4200 --hmr",
     "test": "ng test",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
-    "e2e": "protractor"
+    "e2e": "protractor",
+    "lint": "tslint --force --project src/tsconfig.json src/**/*.ts -t verbose"
   },
   "private": true,
   "dependencies": {

--- a/angular/src/AppPreBootstrap.ts
+++ b/angular/src/AppPreBootstrap.ts
@@ -33,11 +33,11 @@ export class AppPreBootstrap {
     }
 
     private static getCurrentClockProvider(currentProviderName: string): abp.timing.IClockProvider {
-        if (currentProviderName === "unspecifiedClockProvider") {
+        if (currentProviderName === 'unspecifiedClockProvider') {
             return abp.timing.unspecifiedClockProvider;
         }
 
-        if (currentProviderName === "utcClockProvider") {
+        if (currentProviderName === 'utcClockProvider') {
             return abp.timing.utcClockProvider;
         }
 
@@ -50,7 +50,7 @@ export class AppPreBootstrap {
             method: 'GET',
             headers: {
                 Authorization: 'Bearer ' + abp.auth.getToken(),
-                '.AspNetCore.Culture': abp.utils.getCookieValue("Abp.Localization.CultureName"),
+                '.AspNetCore.Culture': abp.utils.getCookieValue('Abp.Localization.CultureName'),
                 'Abp.TenantId': abp.multiTenancy.getTenantIdCookie()
             }
         }).done(result => {

--- a/angular/src/account/account-routing.module.ts
+++ b/angular/src/account/account-routing.module.ts
@@ -1,4 +1,4 @@
-﻿import { NgModule } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { LoginComponent } from './login/login.component';
 import { RegisterComponent } from './register/register.component';

--- a/angular/src/account/account.component.ts
+++ b/angular/src/account/account.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, ViewContainerRef, OnInit, ViewEncapsulation, Injector } from '@angular/core';
+import { Component, ViewContainerRef, OnInit, ViewEncapsulation, Injector } from '@angular/core';
 import { LoginService } from './login/login.service';
 import { AppComponentBase } from '@shared/app-component-base';
 
@@ -11,10 +11,10 @@ import { AppComponentBase } from '@shared/app-component-base';
 })
 export class AccountComponent extends AppComponentBase implements OnInit {
 
-    private viewContainerRef: ViewContainerRef;
-
     versionText: string;
     currentYear: number;
+
+    private viewContainerRef: ViewContainerRef;
 
     public constructor(
         injector: Injector,

--- a/angular/src/account/layout/account-languages.component.ts
+++ b/angular/src/account/layout/account-languages.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, OnInit, Injector } from '@angular/core';
+import { Component, OnInit, Injector } from '@angular/core';
 import { AppComponentBase } from '@shared/app-component-base';
 
 import * as _ from 'lodash';
@@ -28,9 +28,9 @@ export class AccountLanguagesComponent extends AppComponentBase implements OnIni
 
     changeLanguage(languageName: string): void {
         abp.utils.setCookieValue(
-            "Abp.Localization.CultureName",
+            'Abp.Localization.CultureName',
             languageName,
-            new Date(new Date().getTime() + 5 * 365 * 86400000), //5 year
+            new Date(new Date().getTime() + 5 * 365 * 86400000), // 5 year
             abp.appPath
         );
 

--- a/angular/src/account/login/login.component.ts
+++ b/angular/src/account/login/login.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, Injector } from '@angular/core';
+import { Component, Injector } from '@angular/core';
 import { AbpSessionService } from '@abp/session/abp-session.service';
 import { AppComponentBase } from '@shared/app-component-base';
 import { accountModuleAnimation } from '@shared/animations/routerTransition';
@@ -10,7 +10,7 @@ import { LoginService } from './login.service';
   animations: [accountModuleAnimation()]
 })
 export class LoginComponent extends AppComponentBase {
-  submitting: boolean = false;
+  submitting = false;
 
   constructor(
     injector: Injector,

--- a/angular/src/account/login/login.service.ts
+++ b/angular/src/account/login/login.service.ts
@@ -36,7 +36,7 @@ export class LoginService {
 
         this._tokenAuthService
             .authenticate(this.authenticateModel)
-            .pipe(finalize(() => { finallyCallback() }))
+            .pipe(finalize(() => { finallyCallback(); }))
             .subscribe((result: AuthenticateResultModel) => {
                 this.processAuthenticateResult(result);
             });
@@ -46,11 +46,11 @@ export class LoginService {
         this.authenticateResult = authenticateResult;
 
         if (authenticateResult.accessToken) {
-            //Successfully logged in
+            // Successfully logged in
             this.login(authenticateResult.accessToken, authenticateResult.encryptedAccessToken, authenticateResult.expireInSeconds, this.rememberMe);
 
         } else {
-            //Unexpected result!
+            // Unexpected result!
 
             this._logService.warn('Unexpected authenticateResult!');
             this._router.navigate(['account/login']);
@@ -59,7 +59,7 @@ export class LoginService {
 
     private login(accessToken: string, encryptedAccessToken: string, expireInSeconds: number, rememberMe?: boolean): void {
 
-        var tokenExpireDate = rememberMe ? (new Date(new Date().getTime() + 1000 * expireInSeconds)) : undefined;
+        let tokenExpireDate = rememberMe ? (new Date(new Date().getTime() + 1000 * expireInSeconds)) : undefined;
 
         this._tokenService.setToken(
             accessToken,
@@ -73,7 +73,7 @@ export class LoginService {
             abp.appPath
         );
 
-        var initialUrl = UrlHelper.initialUrl;
+        let initialUrl = UrlHelper.initialUrl;
         if (initialUrl.indexOf('/login') > 0) {
             initialUrl = AppConsts.appBaseUrl;
         }

--- a/angular/src/account/login/login.service.ts
+++ b/angular/src/account/login/login.service.ts
@@ -1,14 +1,14 @@
+import { TokenService } from '@abp/auth/token.service';
+import { LogService } from '@abp/log/log.service';
+import { MessageService } from '@abp/message/message.service';
+import { UtilsService } from '@abp/utils/utils.service';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { TokenAuthServiceProxy, AuthenticateModel, AuthenticateResultModel, ExternalLoginProviderInfoModel, ExternalAuthenticateModel, ExternalAuthenticateResultModel } from '@shared/service-proxies/service-proxies';
-import { UrlHelper } from '@shared/helpers/UrlHelper';
 import { AppConsts } from '@shared/AppConsts';
-
-import { MessageService } from '@abp/message/message.service';
-import { LogService } from '@abp/log/log.service';
-import { TokenService } from '@abp/auth/token.service';
-import { UtilsService } from '@abp/utils/utils.service';
+import { UrlHelper } from '@shared/helpers/UrlHelper';
+import { AuthenticateModel, AuthenticateResultModel, TokenAuthServiceProxy } from '@shared/service-proxies/service-proxies';
 import { finalize } from 'rxjs/operators';
+
 
 @Injectable()
 export class LoginService {
@@ -47,7 +47,11 @@ export class LoginService {
 
         if (authenticateResult.accessToken) {
             // Successfully logged in
-            this.login(authenticateResult.accessToken, authenticateResult.encryptedAccessToken, authenticateResult.expireInSeconds, this.rememberMe);
+            this.login(
+                authenticateResult.accessToken,
+                authenticateResult.encryptedAccessToken,
+                authenticateResult.expireInSeconds,
+                this.rememberMe);
 
         } else {
             // Unexpected result!
@@ -59,7 +63,7 @@ export class LoginService {
 
     private login(accessToken: string, encryptedAccessToken: string, expireInSeconds: number, rememberMe?: boolean): void {
 
-        let tokenExpireDate = rememberMe ? (new Date(new Date().getTime() + 1000 * expireInSeconds)) : undefined;
+        const tokenExpireDate = rememberMe ? (new Date(new Date().getTime() + 1000 * expireInSeconds)) : undefined;
 
         this._tokenService.setToken(
             accessToken,

--- a/angular/src/account/register/register.component.ts
+++ b/angular/src/account/register/register.component.ts
@@ -1,18 +1,18 @@
-import { Component, Injector } from "@angular/core";
-import { Router } from "@angular/router";
-import { finalize } from "rxjs/operators";
-import { AppComponentBase } from "@shared/app-component-base";
-import { accountModuleAnimation } from "@shared/animations/routerTransition";
+import { Component, Injector } from '@angular/core';
+import { Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
+import { AppComponentBase } from '@shared/app-component-base';
+import { accountModuleAnimation } from '@shared/animations/routerTransition';
 import {
   AccountServiceProxy,
   RegisterInput,
   RegisterOutput
-} from "@shared/service-proxies/service-proxies";
-import { LoginService } from "../login/login.service";
+} from '@shared/service-proxies/service-proxies';
+import { LoginService } from '../login/login.service';
 
 @Component({
-  templateUrl: "./register.component.html",
-  animations: [accountModuleAnimation()], 
+  templateUrl: './register.component.html',
+  animations: [accountModuleAnimation()],
   styles: [
     `
       mat-form-field {
@@ -26,7 +26,7 @@ import { LoginService } from "../login/login.service";
 })
 export class RegisterComponent extends AppComponentBase {
   model: RegisterInput = new RegisterInput();
-  saving: boolean = false;
+  saving = false;
 
   constructor(
     injector: Injector,
@@ -38,7 +38,7 @@ export class RegisterComponent extends AppComponentBase {
   }
 
   back(): void {
-    this._router.navigate(["/login"]);
+    this._router.navigate(['/login']);
   }
 
   save(): void {
@@ -52,12 +52,12 @@ export class RegisterComponent extends AppComponentBase {
       )
       .subscribe((result: RegisterOutput) => {
         if (!result.canLogin) {
-          this.notify.success(this.l("SuccessfullyRegistered"));
-          this._router.navigate(["/login"]);
+          this.notify.success(this.l('SuccessfullyRegistered'));
+          this._router.navigate(['/login']);
           return;
         }
 
-        //Autheticate
+        // Autheticate
         this.saving = true;
         this._loginService.authenticateModel.userNameOrEmailAddress = this.model.userName;
         this._loginService.authenticateModel.password = this.model.password;

--- a/angular/src/app/about/about.component.ts
+++ b/angular/src/app/about/about.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, Injector, AfterViewInit } from '@angular/core';
+import { Component, Injector, AfterViewInit } from '@angular/core';
 import { AppComponentBase } from '@shared/app-component-base';
 import { appModuleAnimation } from '@shared/animations/routerTransition';
 

--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -23,8 +23,8 @@ export class AppComponent extends AppComponentBase implements OnInit, AfterViewI
         abp.event.on('abp.notifications.received', userNotification => {
             abp.notifications.showUiNotifyForUserNotification(userNotification);
 
-            //Desktop notification
-            Push.create("AbpZeroTemplate", {
+            // Desktop notification
+            Push.create('AbpZeroTemplate', {
                 body: userNotification.notification.data.message,
                 icon: abp.appPath + 'assets/app-logo-small.png',
                 timeout: 6000,

--- a/angular/src/app/home/home.component.ts
+++ b/angular/src/app/home/home.component.ts
@@ -35,7 +35,7 @@ export class HomeComponent extends AppComponentBase implements AfterViewInit {
         let realtime = 'on';
         function initRealTimeChart() {
             // Real time ==========================================================================================
-            let plot = ($ as any).plot('#real_time_chart', [getRandomData()], {
+            const plot = ($ as any).plot('#real_time_chart', [getRandomData()], {
                 series: {
                     shadowSize: 0,
                     color: 'rgb(0, 188, 212)'
@@ -81,7 +81,7 @@ export class HomeComponent extends AppComponentBase implements AfterViewInit {
 
         function initSparkline() {
             $('.sparkline').each(function () {
-                let $this = $(this);
+                const $this = $(this);
                 $this.sparkline('html', $this.data());
             });
         }
@@ -113,18 +113,21 @@ export class HomeComponent extends AppComponentBase implements AfterViewInit {
             });
         }
 
-        let data = [], totalPoints = 110;
+        let data = [];
+        const totalPoints = 110;
+
         function getRandomData() {
             if (data.length > 0) { data = data.slice(1); }
 
             while (data.length < totalPoints) {
-                let prev = data.length > 0 ? data[data.length - 1] : 50, y = prev + Math.random() * 10 - 5;
+                const prev = data.length > 0 ? data[data.length - 1] : 50;
+                let y = prev + Math.random() * 10 - 5;
                 if (y < 0) { y = 0; } else if (y > 100) { y = 100; }
 
                 data.push(y);
             }
 
-            let res = [];
+            const res = [];
             for (let i = 0; i < data.length; ++i) {
                 res.push([i, data[i]]);
             }

--- a/angular/src/app/home/home.component.ts
+++ b/angular/src/app/home/home.component.ts
@@ -17,10 +17,10 @@ export class HomeComponent extends AppComponentBase implements AfterViewInit {
     ngAfterViewInit(): void {
 
         $(function () {
-            //Widgets count
+            // Widgets count
             $('.count-to').countTo();
 
-            //Sales count to
+            // Sales count to
             $('.sales-count-to').countTo({
                 formatter: function (value, options) {
                     return '$' + value.toFixed(2).replace(/(\d)(?=(\d\d\d)+(?!\d))/g, ' ').replace('.', ',');
@@ -32,10 +32,10 @@ export class HomeComponent extends AppComponentBase implements AfterViewInit {
             initSparkline();
         });
 
-        var realtime = 'on';
+        let realtime = 'on';
         function initRealTimeChart() {
-            //Real time ==========================================================================================
-            var plot = ($ as any).plot('#real_time_chart', [getRandomData()], {
+            // Real time ==========================================================================================
+            let plot = ($ as any).plot('#real_time_chart', [getRandomData()], {
                 series: {
                     shadowSize: 0,
                     color: 'rgb(0, 188, 212)'
@@ -62,7 +62,7 @@ export class HomeComponent extends AppComponentBase implements AfterViewInit {
                 plot.setData([getRandomData()]);
                 plot.draw();
 
-                var timeout;
+                let timeout;
                 if (realtime === 'on') {
                     timeout = setTimeout(updateRealTime, 320);
                 } else {
@@ -76,12 +76,12 @@ export class HomeComponent extends AppComponentBase implements AfterViewInit {
                 realtime = (this as any).checked ? 'on' : 'off';
                 updateRealTime();
             });
-            //====================================================================================================
+            // ====================================================================================================
         }
 
         function initSparkline() {
-            $(".sparkline").each(function () {
-                var $this = $(this);
+            $('.sparkline').each(function () {
+                let $this = $(this);
                 $this.sparkline('html', $this.data());
             });
         }
@@ -108,24 +108,24 @@ export class HomeComponent extends AppComponentBase implements AfterViewInit {
                     }],
                 colors: ['rgb(233, 30, 99)', 'rgb(0, 188, 212)', 'rgb(255, 152, 0)', 'rgb(0, 150, 136)', 'rgb(96, 125, 139)'],
                 formatter: function (y) {
-                    return y + '%'
+                    return y + '%';
                 }
             });
         }
 
-        var data = [], totalPoints = 110;
+        let data = [], totalPoints = 110;
         function getRandomData() {
-            if (data.length > 0) data = data.slice(1);
+            if (data.length > 0) { data = data.slice(1); }
 
             while (data.length < totalPoints) {
-                var prev = data.length > 0 ? data[data.length - 1] : 50, y = prev + Math.random() * 10 - 5;
+                let prev = data.length > 0 ? data[data.length - 1] : 50, y = prev + Math.random() * 10 - 5;
                 if (y < 0) { y = 0; } else if (y > 100) { y = 100; }
 
                 data.push(y);
             }
 
-            var res = [];
-            for (var i = 0; i < data.length; ++i) {
+            let res = [];
+            for (let i = 0; i < data.length; ++i) {
                 res.push([i, data[i]]);
             }
 

--- a/angular/src/app/layout/right-sidebar.component.ts
+++ b/angular/src/app/layout/right-sidebar.component.ts
@@ -2,6 +2,13 @@ import { Component, Injector, ViewEncapsulation, OnInit } from '@angular/core';
 import { AppComponentBase } from '@shared/app-component-base';
 import { ConfigurationServiceProxy, ChangeUiThemeInput } from '@shared/service-proxies/service-proxies';
 
+class UiThemeInfo {
+    constructor(
+        public name: string,
+        public cssClass: string
+    ) { }
+}
+
 @Component({
     templateUrl: './right-sidebar.component.html',
     selector: 'right-sidebar',
@@ -62,9 +69,3 @@ export class RightSideBarComponent extends AppComponentBase implements OnInit {
     }
 }
 
-class UiThemeInfo {
-    constructor(
-        public name: string,
-        public cssClass: string
-    ) { }
-}

--- a/angular/src/app/layout/right-sidebar.component.ts
+++ b/angular/src/app/layout/right-sidebar.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, Injector, ViewEncapsulation, OnInit } from '@angular/core';
+import { Component, Injector, ViewEncapsulation, OnInit } from '@angular/core';
 import { AppComponentBase } from '@shared/app-component-base';
 import { ConfigurationServiceProxy, ChangeUiThemeInput } from '@shared/service-proxies/service-proxies';
 
@@ -10,29 +10,29 @@ import { ConfigurationServiceProxy, ChangeUiThemeInput } from '@shared/service-p
 export class RightSideBarComponent extends AppComponentBase implements OnInit {
 
     themes: UiThemeInfo[] = [
-        new UiThemeInfo("Red", "red"),
-        new UiThemeInfo("Pink", "pink"),
-        new UiThemeInfo("Purple", "purple"),
-        new UiThemeInfo("Deep Purple", "deep-purple"),
-        new UiThemeInfo("Indigo", "indigo"),
-        new UiThemeInfo("Blue", "blue"),
-        new UiThemeInfo("Light Blue", "light-blue"),
-        new UiThemeInfo("Cyan", "cyan"),
-        new UiThemeInfo("Teal", "teal"),
-        new UiThemeInfo("Green", "green"),
-        new UiThemeInfo("Light Green", "light-green"),
-        new UiThemeInfo("Lime", "lime"),
-        new UiThemeInfo("Yellow", "yellow"),
-        new UiThemeInfo("Amber", "amber"),
-        new UiThemeInfo("Orange", "orange"),
-        new UiThemeInfo("Deep Orange", "deep-orange"),
-        new UiThemeInfo("Brown", "brown"),
-        new UiThemeInfo("Grey", "grey"),
-        new UiThemeInfo("Blue Grey", "blue-grey"),
-        new UiThemeInfo("Black", "black")
+        new UiThemeInfo('Red', 'red'),
+        new UiThemeInfo('Pink', 'pink'),
+        new UiThemeInfo('Purple', 'purple'),
+        new UiThemeInfo('Deep Purple', 'deep-purple'),
+        new UiThemeInfo('Indigo', 'indigo'),
+        new UiThemeInfo('Blue', 'blue'),
+        new UiThemeInfo('Light Blue', 'light-blue'),
+        new UiThemeInfo('Cyan', 'cyan'),
+        new UiThemeInfo('Teal', 'teal'),
+        new UiThemeInfo('Green', 'green'),
+        new UiThemeInfo('Light Green', 'light-green'),
+        new UiThemeInfo('Lime', 'lime'),
+        new UiThemeInfo('Yellow', 'yellow'),
+        new UiThemeInfo('Amber', 'amber'),
+        new UiThemeInfo('Orange', 'orange'),
+        new UiThemeInfo('Deep Orange', 'deep-orange'),
+        new UiThemeInfo('Brown', 'brown'),
+        new UiThemeInfo('Grey', 'grey'),
+        new UiThemeInfo('Blue Grey', 'blue-grey'),
+        new UiThemeInfo('Black', 'black')
     ];
 
-    selectedThemeCssClass: string = "red";
+    selectedThemeCssClass = 'red';
 
     constructor(
         injector: Injector,

--- a/angular/src/app/layout/sidebar-footer.component.ts
+++ b/angular/src/app/layout/sidebar-footer.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, Injector, ViewEncapsulation } from '@angular/core';
+import { Component, Injector, ViewEncapsulation } from '@angular/core';
 import { AppComponentBase } from '@shared/app-component-base';
 
 @Component({

--- a/angular/src/app/layout/sidebar-nav.component.ts
+++ b/angular/src/app/layout/sidebar-nav.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, Injector, ViewEncapsulation } from '@angular/core';
+import { Component, Injector, ViewEncapsulation } from '@angular/core';
 import { AppComponentBase } from '@shared/app-component-base';
 import { MenuItem } from '@shared/layout/menu-item';
 
@@ -10,27 +10,27 @@ import { MenuItem } from '@shared/layout/menu-item';
 export class SideBarNavComponent extends AppComponentBase {
 
     menuItems: MenuItem[] = [
-        new MenuItem(this.l("HomePage"), "", "home", "/app/home"),
+        new MenuItem(this.l('HomePage'), '', 'home', '/app/home'),
 
-        new MenuItem(this.l("Tenants"), "Pages.Tenants", "business", "/app/tenants"),
-        new MenuItem(this.l("Users"), "Pages.Users", "people", "/app/users"),
-        new MenuItem(this.l("Roles"), "Pages.Roles", "local_offer", "/app/roles"),
-        new MenuItem(this.l("About"), "", "info", "/app/about"),
+        new MenuItem(this.l('Tenants'), 'Pages.Tenants', 'business', '/app/tenants'),
+        new MenuItem(this.l('Users'), 'Pages.Users', 'people', '/app/users'),
+        new MenuItem(this.l('Roles'), 'Pages.Roles', 'local_offer', '/app/roles'),
+        new MenuItem(this.l('About'), '', 'info', '/app/about'),
 
-        new MenuItem(this.l("MultiLevelMenu"), "", "menu", "", [
-            new MenuItem("ASP.NET Boilerplate", "", "", "", [
-                new MenuItem("Home", "", "", "https://aspnetboilerplate.com/?ref=abptmpl"),
-                new MenuItem("Templates", "", "", "https://aspnetboilerplate.com/Templates?ref=abptmpl"),
-                new MenuItem("Samples", "", "", "https://aspnetboilerplate.com/Samples?ref=abptmpl"),
-                new MenuItem("Documents", "", "", "https://aspnetboilerplate.com/Pages/Documents?ref=abptmpl")
+        new MenuItem(this.l('MultiLevelMenu'), '', 'menu', '', [
+            new MenuItem('ASP.NET Boilerplate', '', '', '', [
+                new MenuItem('Home', '', '', 'https://aspnetboilerplate.com/?ref=abptmpl'),
+                new MenuItem('Templates', '', '', 'https://aspnetboilerplate.com/Templates?ref=abptmpl'),
+                new MenuItem('Samples', '', '', 'https://aspnetboilerplate.com/Samples?ref=abptmpl'),
+                new MenuItem('Documents', '', '', 'https://aspnetboilerplate.com/Pages/Documents?ref=abptmpl')
             ]),
-            new MenuItem("ASP.NET Zero", "", "", "", [
-                new MenuItem("Home", "", "", "https://aspnetzero.com?ref=abptmpl"),
-                new MenuItem("Description", "", "", "https://aspnetzero.com/?ref=abptmpl#description"),
-                new MenuItem("Features", "", "", "https://aspnetzero.com/?ref=abptmpl#features"),
-                new MenuItem("Pricing", "", "", "https://aspnetzero.com/?ref=abptmpl#pricing"),
-                new MenuItem("Faq", "", "", "https://aspnetzero.com/Faq?ref=abptmpl"),
-                new MenuItem("Documents", "", "", "https://aspnetzero.com/Documents?ref=abptmpl")
+            new MenuItem('ASP.NET Zero', '', '', '', [
+                new MenuItem('Home', '', '', 'https://aspnetzero.com?ref=abptmpl'),
+                new MenuItem('Description', '', '', 'https://aspnetzero.com/?ref=abptmpl#description'),
+                new MenuItem('Features', '', '', 'https://aspnetzero.com/?ref=abptmpl#features'),
+                new MenuItem('Pricing', '', '', 'https://aspnetzero.com/?ref=abptmpl#pricing'),
+                new MenuItem('Faq', '', '', 'https://aspnetzero.com/Faq?ref=abptmpl'),
+                new MenuItem('Documents', '', '', 'https://aspnetzero.com/Documents?ref=abptmpl')
             ])
         ])
     ];

--- a/angular/src/app/layout/sidebar-user-area.component.ts
+++ b/angular/src/app/layout/sidebar-user-area.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, OnInit, Injector, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, Injector, ViewEncapsulation } from '@angular/core';
 import { AppComponentBase } from '@shared/app-component-base';
 import { AppAuthService } from '@shared/auth/app-auth.service';
 
@@ -9,7 +9,7 @@ import { AppAuthService } from '@shared/auth/app-auth.service';
 })
 export class SideBarUserAreaComponent extends AppComponentBase implements OnInit {
 
-    shownLoginName: string = "";
+    shownLoginName = '';
 
     constructor(
         injector: Injector,

--- a/angular/src/app/layout/topbar-languageswitch.component.ts
+++ b/angular/src/app/layout/topbar-languageswitch.component.ts
@@ -13,7 +13,7 @@ export class TopBarLanguageSwitchComponent extends AppComponentBase implements O
 
   languages: abp.localization.ILanguageInfo[];
   currentLanguage: abp.localization.ILanguageInfo;
-  
+
   constructor(
       injector: Injector,
       private _userService: UserServiceProxy
@@ -34,7 +34,7 @@ export class TopBarLanguageSwitchComponent extends AppComponentBase implements O
           abp.utils.setCookieValue(
               'Abp.Localization.CultureName',
               languageName,
-              new Date(new Date().getTime() + 5 * 365 * 86400000), //5 year
+              new Date(new Date().getTime() + 5 * 365 * 86400000), // 5 year
               abp.appPath
           );
 

--- a/angular/src/app/layout/topbar.component.ts
+++ b/angular/src/app/layout/topbar.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, Injector, ViewEncapsulation } from '@angular/core';
+import { Component, Injector, ViewEncapsulation } from '@angular/core';
 import { AppComponentBase } from '@shared/app-component-base';
 
 @Component({

--- a/angular/src/app/users/change-password/change-password.component.ts
+++ b/angular/src/app/users/change-password/change-password.component.ts
@@ -20,10 +20,6 @@ export class FormGroupErrorStateMatcher implements ErrorStateMatcher {
     templateUrl: './change-password.component.html'
 })
 export class ChangePasswordComponent extends AppComponentBase implements OnInit {
-    public parentFormGroup: FormGroup;
-    public passwordsFormGroup: FormGroup;
-    public isLoading: boolean;
-    public equalMatcher: FormGroupErrorStateMatcher;
 
     private static areEqual(c: AbstractControl): ValidationErrors | null {
         const keys: string[] = Object.keys(c.value);
@@ -33,6 +29,10 @@ export class ChangePasswordComponent extends AppComponentBase implements OnInit 
             }
         }
     }
+    public parentFormGroup: FormGroup;
+    public passwordsFormGroup: FormGroup;
+    public isLoading: boolean;
+    public equalMatcher: FormGroupErrorStateMatcher;
 
     public constructor(
         injector: Injector,

--- a/angular/src/app/users/users.component.ts
+++ b/angular/src/app/users/users.component.ts
@@ -38,6 +38,18 @@ export class UsersComponent extends PagedListingComponentBase<UserDto> {
         super(injector);
     }
 
+    createUser(): void {
+        this.showCreateOrEditUserDialog();
+    }
+
+    editUser(user: UserDto): void {
+        this.showCreateOrEditUserDialog(user.id);
+    }
+
+    public resetPassword(user: UserDto): void {
+        this.showResetPasswordUserDialog(user.id);
+    }
+
     protected list(
         request: PagedUsersRequestDto,
         pageNumber: number,
@@ -72,18 +84,6 @@ export class UsersComponent extends PagedListingComponentBase<UserDto> {
                 }
             }
         );
-    }
-
-    createUser(): void {
-        this.showCreateOrEditUserDialog();
-    }
-
-    editUser(user: UserDto): void {
-        this.showCreateOrEditUserDialog(user.id);
-    }
-
-    public resetPassword(user: UserDto): void {
-        this.showResetPasswordUserDialog(user.id);
     }
 
     private showResetPasswordUserDialog(userId?: number): void {

--- a/angular/src/hmr.ts
+++ b/angular/src/hmr.ts
@@ -1,4 +1,4 @@
-﻿import { NgModuleRef, ApplicationRef } from '@angular/core';
+import { NgModuleRef, ApplicationRef } from '@angular/core';
 import { createNewHosts } from '@angularclass/hmr';
 
 export const hmrBootstrap = (module: any, bootstrap: () => Promise<NgModuleRef<any>>) => {
@@ -6,9 +6,9 @@ export const hmrBootstrap = (module: any, bootstrap: () => Promise<NgModuleRef<a
     module.hot.accept();
     bootstrap().then(mod => ngModule = mod);
     module.hot.dispose(() => {
-        let appRef: ApplicationRef = ngModule.injector.get(ApplicationRef);
-        let elements = appRef.components.map(c => c.location.nativeElement);
-        let makeVisible = createNewHosts(elements);
+        const appRef: ApplicationRef = ngModule.injector.get(ApplicationRef);
+        const elements = appRef.components.map(c => c.location.nativeElement);
+        const makeVisible = createNewHosts(elements);
         ngModule.destroy();
         makeVisible();
     });

--- a/angular/src/main.ts
+++ b/angular/src/main.ts
@@ -24,11 +24,11 @@ const bootstrap = () => {
 
 if (environment.hmr) {
     if (module['hot']) {
-        hmrBootstrap(module, bootstrap); //HMR enabled bootstrap
+        hmrBootstrap(module, bootstrap); // HMR enabled bootstrap
     } else {
         console.error('HMR is not enabled for webpack-dev-server!');
         console.log('Are you using the --hmr flag for ng serve?');
     }
 } else {
-    bootstrap(); //Regular bootstrap
+    bootstrap(); // Regular bootstrap
 }

--- a/angular/src/root-routing.module.ts
+++ b/angular/src/root-routing.module.ts
@@ -1,16 +1,16 @@
-﻿import { NgModule } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 const routes: Routes = [
     { path: '', redirectTo: '/app/home', pathMatch: 'full' },
     {
         path: 'account',
-        loadChildren: 'account/account.module#AccountModule', //Lazy load account module
+        loadChildren: 'account/account.module#AccountModule', // Lazy load account module
         data: { preload: true }
     },
     {
         path: 'app',
-        loadChildren: 'app/app.module#AppModule', //Lazy load account module
+        loadChildren: 'app/app.module#AppModule', // Lazy load account module
         data: { preload: true }
     }
 ];

--- a/angular/src/root.component.ts
+++ b/angular/src/root.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
     selector: 'app-root',

--- a/angular/src/root.module.ts
+++ b/angular/src/root.module.ts
@@ -31,17 +31,17 @@ export function appInitializerFactory(injector: Injector,
         abp.ui.setBusy();
         return new Promise<boolean>((resolve, reject) => {
             AppConsts.appBaseHref = getBaseHref(platformLocation);
-            let appBaseUrl = getDocumentOrigin() + AppConsts.appBaseHref;
+            const appBaseUrl = getDocumentOrigin() + AppConsts.appBaseHref;
 
             AppPreBootstrap.run(appBaseUrl, () => {
                 abp.event.trigger('abp.dynamicScriptsInitialized');
-                var appSessionService: AppSessionService = injector.get(AppSessionService);
+                const appSessionService: AppSessionService = injector.get(AppSessionService);
                 appSessionService.init().then(
                     (result) => {
                         abp.ui.clearBusy();
 
                         if (shouldLoadLocale()) {
-                            let angularLocale = convertAbpLocaleToAngularLocale(abp.localization.currentLanguage.name);
+                            const angularLocale = convertAbpLocaleToAngularLocale(abp.localization.currentLanguage.name);
                             import(`@angular/common/locales/${angularLocale}.js`)
                                 .then(module => {
                                     registerLocaleData(module.default);
@@ -58,7 +58,7 @@ export function appInitializerFactory(injector: Injector,
                 );
             });
         });
-    }
+    };
 }
 
 export function convertAbpLocaleToAngularLocale(locale: string): string {
@@ -66,7 +66,7 @@ export function convertAbpLocaleToAngularLocale(locale: string): string {
         return locale;
     }
 
-    let localeMapings = _.filter(AppConsts.localeMappings, { from: locale });
+    const localeMapings = _.filter(AppConsts.localeMappings, { from: locale });
     if (localeMapings && localeMapings.length) {
         return localeMapings[0]['to'];
     }
@@ -123,7 +123,7 @@ export class RootModule {
 }
 
 export function getBaseHref(platformLocation: PlatformLocation): string {
-    var baseUrl = platformLocation.getBaseHrefFromDOM();
+    const baseUrl = platformLocation.getBaseHrefFromDOM();
     if (baseUrl) {
         return baseUrl;
     }
@@ -133,7 +133,7 @@ export function getBaseHref(platformLocation: PlatformLocation): string {
 
 function getDocumentOrigin() {
     if (!document.location.origin) {
-        return document.location.protocol + "//" + document.location.hostname + (document.location.port ? ':' + document.location.port : '');
+        return document.location.protocol + '//' + document.location.hostname + (document.location.port ? ':' + document.location.port : '');
     }
 
     return document.location.origin;

--- a/angular/src/root.module.ts
+++ b/angular/src/root.module.ts
@@ -133,7 +133,8 @@ export function getBaseHref(platformLocation: PlatformLocation): string {
 
 function getDocumentOrigin() {
     if (!document.location.origin) {
-        return document.location.protocol + '//' + document.location.hostname + (document.location.port ? ':' + document.location.port : '');
+        const port = document.location.port ? ':' + document.location.port : '';
+        return document.location.protocol + '//' + document.location.hostname + port;
     }
 
     return document.location.origin;

--- a/angular/src/shared/AppEnums.ts
+++ b/angular/src/shared/AppEnums.ts
@@ -1,4 +1,4 @@
-﻿import { IsTenantAvailableOutputState } from '@shared/service-proxies/service-proxies';
+import { IsTenantAvailableOutputState } from '@shared/service-proxies/service-proxies';
 
 
 export class AppTenantAvailabilityState {

--- a/angular/src/shared/auth/app-auth.service.ts
+++ b/angular/src/shared/auth/app-auth.service.ts
@@ -1,4 +1,4 @@
-﻿import { Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { AppConsts } from '@shared/AppConsts';
 
 @Injectable()

--- a/angular/src/shared/auth/auth-route-guard.ts
+++ b/angular/src/shared/auth/auth-route-guard.ts
@@ -1,4 +1,4 @@
-﻿import { Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { PermissionCheckerService } from '@abp/auth/permission-checker.service';
 import { AppSessionService } from '../session/app-session.service';
 
@@ -24,11 +24,11 @@ export class AppRouteGuard implements CanActivate, CanActivateChild {
             return false;
         }
 
-        if (!route.data || !route.data["permission"]) {
+        if (!route.data || !route.data['permission']) {
             return true;
         }
 
-        if (this._permissionChecker.isGranted(route.data["permission"])) {
+        if (this._permissionChecker.isGranted(route.data['permission'])) {
             return true;
         }
 
@@ -44,7 +44,7 @@ export class AppRouteGuard implements CanActivate, CanActivateChild {
         if (!this._sessionService.user) {
             return '/account/login';
         }
-        
+
         if (this._permissionChecker.isGranted('Pages.Users')) {
             return '/app/admin/users';
         }

--- a/angular/src/shared/directives/block.directive.ts
+++ b/angular/src/shared/directives/block.directive.ts
@@ -5,14 +5,15 @@ import {
     Injectable,
     HostListener,
     Input,
-    SimpleChanges
+    SimpleChanges,
+    OnChanges
 } from '@angular/core';
 
 @Directive({
     selector: '[block]'
 })
 @Injectable()
-export class BlockDirective implements AfterViewInit {
+export class BlockDirective implements AfterViewInit, OnChanges {
     @Input('block') loading: boolean;
     private $element: JQuery;
 

--- a/angular/src/shared/directives/busy.directive.ts
+++ b/angular/src/shared/directives/busy.directive.ts
@@ -5,14 +5,15 @@ import {
     Injectable,
     HostListener,
     Input,
-    SimpleChanges
+    SimpleChanges,
+    OnChanges
 } from '@angular/core';
 
 @Directive({
     selector: '[busy]'
 })
 @Injectable()
-export class BusyDirective implements AfterViewInit {
+export class BusyDirective implements AfterViewInit, OnChanges {
     @Input('busy') loading: boolean;
     private $element: JQuery;
 

--- a/angular/src/shared/helpers/SignalRAspNetCoreHelper.ts
+++ b/angular/src/shared/helpers/SignalRAspNetCoreHelper.ts
@@ -4,7 +4,7 @@ import { UtilsService } from '@abp/utils/utils.service';
 export class SignalRAspNetCoreHelper {
     static initSignalR(): void {
 
-        let encryptedAuthToken = new UtilsService().getCookieValue(AppConsts.authorization.encrptedAuthTokenName);
+        const encryptedAuthToken = new UtilsService().getCookieValue(AppConsts.authorization.encrptedAuthTokenName);
 
         abp.signalr = {
             autoConnect: true,

--- a/angular/src/shared/helpers/SignalRAspNetCoreHelper.ts
+++ b/angular/src/shared/helpers/SignalRAspNetCoreHelper.ts
@@ -4,13 +4,13 @@ import { UtilsService } from '@abp/utils/utils.service';
 export class SignalRAspNetCoreHelper {
     static initSignalR(): void {
 
-        var encryptedAuthToken = new UtilsService().getCookieValue(AppConsts.authorization.encrptedAuthTokenName);
+        let encryptedAuthToken = new UtilsService().getCookieValue(AppConsts.authorization.encrptedAuthTokenName);
 
         abp.signalr = {
             autoConnect: true,
             connect: undefined,
             hubs: undefined,
-            qs: AppConsts.authorization.encrptedAuthTokenName + "=" + encodeURIComponent(encryptedAuthToken),
+            qs: AppConsts.authorization.encrptedAuthTokenName + '=' + encodeURIComponent(encryptedAuthToken),
             remoteServiceBaseUrl: AppConsts.remoteServiceBaseUrl,
             startConnection: undefined,
             url: '/signalr'

--- a/angular/src/shared/helpers/UrlHelper.ts
+++ b/angular/src/shared/helpers/UrlHelper.ts
@@ -5,6 +5,9 @@ export class UrlHelper {
     static readonly initialUrl = location.href;
 
     static getQueryParameters(): any {
-        return document.location.search.replace(/(^\?)/, '').split('&').map(function (n) { return n = n.split('='), this[n[0]] = n[1], this; }.bind({}))[0];
+        return document.location.search
+            .replace(/(^\?)/, '')
+            .split('&')
+            .map(function (n) { return n = n.split('='), this[n[0]] = n[1], this; }.bind({}))[0];
     }
 }

--- a/angular/src/shared/helpers/UrlHelper.ts
+++ b/angular/src/shared/helpers/UrlHelper.ts
@@ -1,10 +1,10 @@
-﻿export class UrlHelper {
+export class UrlHelper {
     /**
      * The URL requested, before initial routing.
      */
     static readonly initialUrl = location.href;
 
     static getQueryParameters(): any {
-        return document.location.search.replace(/(^\?)/, '').split("&").map(function (n) { return n = n.split("="), this[n[0]] = n[1], this }.bind({}))[0];
+        return document.location.search.replace(/(^\?)/, '').split('&').map(function (n) { return n = n.split('='), this[n[0]] = n[1], this; }.bind({}))[0];
     }
 }

--- a/angular/src/shared/layout/menu-item.ts
+++ b/angular/src/shared/layout/menu-item.ts
@@ -1,8 +1,8 @@
 export class MenuItem {
-    name: string = '';
-    permissionName: string = '';
-    icon: string = '';
-    route: string = '';
+    name = '';
+    permissionName = '';
+    icon = '';
+    route = '';
     items: MenuItem[];
 
     constructor(name: string, permissionName: string, icon: string, route: string, childItems: MenuItem[] = null) {

--- a/angular/src/shared/nav/app-url.service.ts
+++ b/angular/src/shared/nav/app-url.service.ts
@@ -1,11 +1,11 @@
-﻿import { Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { AppConsts } from '@shared/AppConsts';
 import { AppSessionService } from '../session/app-session.service';
 
 @Injectable()
 export class AppUrlService {
 
-    static tenancyNamePlaceHolder: string = '{TENANCY_NAME}';
+    static tenancyNamePlaceHolder = '{TENANCY_NAME}';
 
     constructor(
         private readonly _appSessionService: AppSessionService
@@ -32,7 +32,7 @@ export class AppUrlService {
         }
 
         if (baseUrl.indexOf(AppUrlService.tenancyNamePlaceHolder + '.') >= 0) {
-            baseUrl = baseUrl.replace(AppUrlService.tenancyNamePlaceHolder + ".", AppUrlService.tenancyNamePlaceHolder);
+            baseUrl = baseUrl.replace(AppUrlService.tenancyNamePlaceHolder + '.', AppUrlService.tenancyNamePlaceHolder);
             if (tenancyName) {
                 tenancyName = tenancyName + '.';
             }

--- a/angular/src/shared/paged-listing-component-base.ts
+++ b/angular/src/shared/paged-listing-component-base.ts
@@ -15,7 +15,7 @@ export class PagedRequestDto {
     maxResultCount: number;
 }
 
-export abstract class PagedListingComponentBase<EntityDto> extends AppComponentBase implements OnInit {
+export abstract class PagedListingComponentBase<TEntityDto> extends AppComponentBase implements OnInit {
 
     public pageSize = 10;
     public pageNumber = 1;
@@ -43,7 +43,7 @@ export abstract class PagedListingComponentBase<EntityDto> extends AppComponentB
     }
 
     public getDataPage(page: number): void {
-        let req = new PagedRequestDto();
+        const req = new PagedRequestDto();
         req.maxResultCount = this.pageSize;
         req.skipCount = (page - 1) * this.pageSize;
 
@@ -54,5 +54,5 @@ export abstract class PagedListingComponentBase<EntityDto> extends AppComponentB
     }
 
     protected abstract list(request: PagedRequestDto, pageNumber: number, finishedCallback: Function): void;
-    protected abstract delete(entity: EntityDto): void;
+    protected abstract delete(entity: TEntityDto): void;
 }

--- a/angular/src/shared/paged-listing-component-base.ts
+++ b/angular/src/shared/paged-listing-component-base.ts
@@ -1,4 +1,4 @@
-﻿import { AppComponentBase } from 'shared/app-component-base';
+import { AppComponentBase } from 'shared/app-component-base';
 import { Injector, OnInit } from '@angular/core';
 
 export class PagedResultDto {
@@ -17,9 +17,9 @@ export class PagedRequestDto {
 
 export abstract class PagedListingComponentBase<EntityDto> extends AppComponentBase implements OnInit {
 
-    public pageSize: number = 10;
-    public pageNumber: number = 1;
-    public totalPages: number = 1;
+    public pageSize = 10;
+    public pageNumber = 1;
+    public totalPages = 1;
     public totalItems: number;
     public isTableLoading = false;
 
@@ -43,7 +43,7 @@ export abstract class PagedListingComponentBase<EntityDto> extends AppComponentB
     }
 
     public getDataPage(page: number): void {
-        var req = new PagedRequestDto();
+        let req = new PagedRequestDto();
         req.maxResultCount = this.pageSize;
         req.skipCount = (page - 1) * this.pageSize;
 

--- a/angular/src/shared/pagination/abp-pagination-controls.component.ts
+++ b/angular/src/shared/pagination/abp-pagination-controls.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter, ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core'
+import {Component, Input, Output, EventEmitter, ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
 
 @Component({
   selector: 'abp-pagination-controls',

--- a/angular/src/shared/session/app-session.service.ts
+++ b/angular/src/shared/session/app-session.service.ts
@@ -1,6 +1,6 @@
-﻿import { Injectable } from '@angular/core';
-import { SessionServiceProxy, UserLoginInfoDto, TenantLoginInfoDto, ApplicationInfoDto, GetCurrentLoginInformationsOutput } from '@shared/service-proxies/service-proxies'
-import { AbpMultiTenancyService } from '@abp/multi-tenancy/abp-multi-tenancy.service'
+import { Injectable } from '@angular/core';
+import { SessionServiceProxy, UserLoginInfoDto, TenantLoginInfoDto, ApplicationInfoDto, GetCurrentLoginInformationsOutput } from '@shared/service-proxies/service-proxies';
+import { AbpMultiTenancyService } from '@abp/multi-tenancy/abp-multi-tenancy.service';
 
 @Injectable()
 export class AppSessionService {
@@ -35,12 +35,12 @@ export class AppSessionService {
     }
 
     getShownLoginName(): string {
-        let userName = this._user.userName;
+        const userName = this._user.userName;
         if (!this._abpMultiTenancyService.isEnabled) {
             return userName;
         }
 
-        return (this._tenant ? this._tenant.tenancyName : ".") + "\\" + userName;
+        return (this._tenant ? this._tenant.tenancyName : '.') + '\\' + userName;
     }
 
     init(): Promise<boolean> {
@@ -49,7 +49,7 @@ export class AppSessionService {
                 this._application = result.application;
                 this._user = result.user;
                 this._tenant = result.tenant;
-                
+
                 resolve(true);
             }, (err) => {
                 reject(err);

--- a/angular/src/shared/session/app-session.service.ts
+++ b/angular/src/shared/session/app-session.service.ts
@@ -1,6 +1,12 @@
-import { Injectable } from '@angular/core';
-import { SessionServiceProxy, UserLoginInfoDto, TenantLoginInfoDto, ApplicationInfoDto, GetCurrentLoginInformationsOutput } from '@shared/service-proxies/service-proxies';
 import { AbpMultiTenancyService } from '@abp/multi-tenancy/abp-multi-tenancy.service';
+import { Injectable } from '@angular/core';
+import {
+    ApplicationInfoDto,
+    GetCurrentLoginInformationsOutput,
+    SessionServiceProxy,
+    TenantLoginInfoDto,
+    UserLoginInfoDto
+} from '@shared/service-proxies/service-proxies';
 
 @Injectable()
 export class AppSessionService {

--- a/angular/src/shared/shared.module.ts
+++ b/angular/src/shared/shared.module.ts
@@ -160,6 +160,6 @@ export class SharedModule {
                 AppAuthService,
                 AppRouteGuard
             ]
-        }
+        };
     }
 }

--- a/angular/src/typings.d.ts
+++ b/angular/src/typings.d.ts
@@ -13,8 +13,8 @@
 
 declare var System: any;
 
-declare var App: any; //Related to Metronic
-declare var Layout: any; //Related to Metronic
+declare var App: any; // Related to Metronic
+declare var Layout: any; // Related to Metronic
 
 declare var Push: any;
 

--- a/angular/tslint.json
+++ b/angular/tslint.json
@@ -12,7 +12,9 @@
     "curly": true,
     "eofline": true,
     "forin": true,
-    "import-blacklist": [true],
+    "import-blacklist": [
+      true
+    ],
     "import-spacing": true,
     "indent": [
       true,
@@ -27,8 +29,9 @@
     "member-access": false,
     "member-ordering": [
       true,
-      "static-before-instance",
-      "variables-before-functions"
+      {
+        "order": "statics-first"
+      }
     ],
     "no-arg": true,
     "no-bitwise": true,
@@ -70,6 +73,7 @@
     ],
     "radix": true,
     "semicolon": [
+      true,
       "always"
     ],
     "triple-equals": [
@@ -86,7 +90,6 @@
         "variable-declaration": "nospace"
       }
     ],
-    "typeof-compare": true,
     "unified-signatures": true,
     "variable-name": false,
     "whitespace": [
@@ -97,9 +100,18 @@
       "check-separator",
       "check-type"
     ],
-
-    "directive-selector": [true, "attribute", "app", "camelCase"],
-    "component-selector": [true, "element", "app", "kebab-case"],
+    "directive-selector": [
+      true,
+      "attribute",
+      "app",
+      "camelCase"
+    ],
+    "component-selector": [
+      true,
+      "element",
+      "app",
+      "kebab-case"
+    ],
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-host-property-decorator": true,
@@ -108,9 +120,6 @@
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
-    "directive-class-suffix": true,
-    "no-access-missing-member": true,
-    "templates-use-public": true,
-    "invoke-injectable": true
+    "directive-class-suffix": true
   }
 }


### PR DESCRIPTION
I use tslint in my project so I thought I could share back what I did to get it running.

1. I added an npm tasks to run linting.
2. I fixed the tslint.json to work with the latest tslint, mine being `5.12.1` I removed deprecated rules and fixed some faulty configurations.
3. I fixed most of the linting errors throughout the project.

One thing that is still an error is the missing prefixes for custom angular components and directives. The style guide recommends those and they can be configured in the angular.json. I'm not sure whether you guys want to change the default prefix or something, so I left those untouched. However, I would recommend to fix those issues as well, since they clutter the linting errors otherwise.

[Prefix styleguide rule](https://angular.io/guide/styleguide#style-02-07)