### PR TITLE
Fix moment.tz being used with the wrong library

### DIFF
--- a/reactjs/src/index.tsx
+++ b/reactjs/src/index.tsx
@@ -2,7 +2,7 @@ import './index.css';
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import * as moment from 'moment';
+import * as moment from 'moment-timezone';
 
 import App from './App';
 import { BrowserRouter } from 'react-router-dom';


### PR DESCRIPTION
**Bug:** Incidentally, when setting a ClockProvider on the backend, line 25-26 on the frontend would call `moment.tz.setDefault(...)`, however, the incorrect library was imported and would result in an error: "cannot read property setDefault of undefined." moment-timezone is needed to access `moment.tz`.

**Fix:** This fix imports 'moment-timezone' instead of 'moment' to allow moment.tz to be accessed when setting a default timezone in abpUserConfigurationService.