### PR TITLE
Small improvements for theming

### DIFF
--- a/angular/src/account/account.component.ts
+++ b/angular/src/account/account.component.ts
@@ -31,6 +31,6 @@ export class AccountComponent extends AppComponentBase implements OnInit {
     }
 
     ngOnInit(): void {
-        $('body').attr('class', 'login-page');
+        $('body').addClass('login-page');
     }
 }

--- a/angular/src/shared/core.less
+++ b/angular/src/shared/core.less
@@ -81,7 +81,7 @@
     .mat-flat-button.mat-primary:not([disabled]),
     .mat-mini-fab.mat-primary:not([disabled]),
     .mat-raised-button.mat-primary:not([disabled]) {
-        background-color: @color;
+        background-color: @color !important;
     }
     .mat-form-field-invalid .mat-input-element,
     .mat-warn .mat-input-element {

--- a/angular/src/shared/core.less
+++ b/angular/src/shared/core.less
@@ -7,7 +7,6 @@
 @light-blue: #03A9F4;
 @cyan: #00BCD4;
 @teal: #009688;
-@indigo: #3F51B5;
 @green: #4CAF50;
 @light-green: #8BC34A;
 @lime: #CDDC39;
@@ -135,10 +134,6 @@
 
 .theme-teal {
     .make-theme(@teal)
-}
-
-.theme-indigo {
-    .make-theme(@indigo)
 }
 
 .theme-green {


### PR DESCRIPTION
There are 3 modifications here:

- Duplicated code for the "@indigo" theme removed;

- Without the "!important", the .mat-primary styles are not overridden as it should;

- On the AccountComponent, just adding a new class to the <body> don't completely reset the body class existent definitions, if there is any.