### PR TITLE
Material Icons checkbox inline styles removed

### DIFF
--- a/angular/src/app/tenants/tenants.component.html
+++ b/angular/src/app/tenants/tenants.component.html
@@ -75,16 +75,14 @@
               <td>{{ tenant.name }}</td>
               <td align="center">
                 <i
-                  class="material-icons"
+                  class="material-icons check_box"
                   *ngIf="tenant.isActive"
-                  style="color:green;"
                 >
                   check_box
                 </i>
                 <i
-                  class="material-icons"
+                  class="material-icons indeterminate_check_box"
                   *ngIf="!tenant.isActive"
-                  style="color:red;"
                 >
                   indeterminate_check_box
                 </i>

--- a/angular/src/app/users/users.component.html
+++ b/angular/src/app/users/users.component.html
@@ -70,10 +70,10 @@
                             <td>{{ user.fullName }}</td>
                             <td>{{ user.emailAddress }}</td>
                             <td align="center">
-                                <i class="material-icons" *ngIf="user.isActive" style="color:green;">
+                                <i class="material-icons check_box" *ngIf="user.isActive">
                                     check_box
                                 </i>
-                                <i class="material-icons" *ngIf="!user.isActive" style="color:red;">
+                                <i class="material-icons indeterminate_check_box" *ngIf="!user.isActive">
                                     indeterminate_check_box
                                 </i>
                             </td>

--- a/angular/src/bsb-theme/css/style.css
+++ b/angular/src/bsb-theme/css/style.css
@@ -3493,6 +3493,13 @@ section.content {
     border-radius: 0 !important;
     padding: 5px 20px !important; }
 
+/* material-icons check_box ==================== */
+i.material-icons.check_box {
+  color: green; }
+
+i.material-icons.indeterminate_check_box {
+  color: red; }
+
 /* Checkbox & Radio ============================ */
 [type="checkbox"] + label {
   padding-left: 26px;


### PR DESCRIPTION
The angular\src\bsb-theme\css\style.min.css doesn't look like an angular\src\bsb-theme\css\style.css minified, so, I left the style.min.css untouched.