### PR TITLE
Remove unnecessary cookie scheme.

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Application/AbpCompanyName.AbpProjectName.Application.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Application/AbpCompanyName.AbpProjectName.Application.csproj
@@ -16,8 +16,4 @@
     <ProjectReference Include="..\AbpCompanyName.AbpProjectName.Core\AbpCompanyName.AbpProjectName.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  
 </Project>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/AbpCompanyName.AbpProjectName.Core.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/AbpCompanyName.AbpProjectName.Core.csproj
@@ -18,10 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Abp.AutoMapper" Version="5.0.0" />
     <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.EntityFrameworkCore/AbpCompanyName.AbpProjectName.EntityFrameworkCore.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.EntityFrameworkCore/AbpCompanyName.AbpProjectName.EntityFrameworkCore.csproj
@@ -16,10 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/AbpCompanyName.AbpProjectName.Migrator.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/AbpCompanyName.AbpProjectName.Migrator.csproj
@@ -18,10 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Abp.Castle.Log4Net" Version="5.0.0" />
   </ItemGroup>
 

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Core/AbpCompanyName.AbpProjectName.Web.Core.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Core/AbpCompanyName.AbpProjectName.Web.Core.csproj
@@ -25,10 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
     <PackageReference Include="Abp.AspNetCore" Version="5.0.0" />

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Core/AbpProjectNameWebCoreModule.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Core/AbpProjectNameWebCoreModule.cs
@@ -23,10 +23,10 @@ namespace AbpCompanyName.AbpProjectName
      )]
     public class AbpProjectNameWebCoreModule : AbpModule
     {
-        private readonly IHostingEnvironment _env;
+        private readonly IWebHostEnvironment _env;
         private readonly IConfigurationRoot _appConfiguration;
 
-        public AbpProjectNameWebCoreModule(IHostingEnvironment env)
+        public AbpProjectNameWebCoreModule(IWebHostEnvironment env)
         {
             _env = env;
             _appConfiguration = env.GetAppConfiguration();

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Core/Configuration/HostingEnvironmentExtensions.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Core/Configuration/HostingEnvironmentExtensions.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 
 namespace AbpCompanyName.AbpProjectName.Configuration
 {
     public static class HostingEnvironmentExtensions
     {
-        public static IConfigurationRoot GetAppConfiguration(this IHostingEnvironment env)
+        public static IConfigurationRoot GetAppConfiguration(this IWebHostEnvironment env)
         {
             return AppConfigurations.Get(env.ContentRootPath, env.EnvironmentName, env.IsDevelopment());
         }

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/AbpCompanyName.AbpProjectName.Web.Host.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/AbpCompanyName.AbpProjectName.Web.Host.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -8,8 +8,6 @@
     <OutputType>Exe</OutputType>
     <PackageId>AbpCompanyName.AbpProjectName.Web.Host</PackageId>
     <UserSecretsId>AbpCompanyName-AbpProjectName-56C2EF2F-ABD6-4EFC-AAF2-2E81C34E8FB1</UserSecretsId>
-
-    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <LangVersion>7.2</LangVersion>
@@ -31,10 +29,6 @@
     <None Update="wwwroot\**\*">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/AbpProjectNameWebHostModule.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/AbpProjectNameWebHostModule.cs
@@ -10,10 +10,10 @@ namespace AbpCompanyName.AbpProjectName.Web.Host.Startup
        typeof(AbpProjectNameWebCoreModule))]
     public class AbpProjectNameWebHostModule: AbpModule
     {
-        private readonly IHostingEnvironment _env;
+        private readonly IWebHostEnvironment _env;
         private readonly IConfigurationRoot _appConfiguration;
 
-        public AbpProjectNameWebHostModule(IHostingEnvironment env)
+        public AbpProjectNameWebHostModule(IWebHostEnvironment env)
         {
             _env = env;
             _appConfiguration = env.GetAppConfiguration();

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs
@@ -27,7 +27,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Host.Startup
 
         private readonly IConfigurationRoot _appConfiguration;
 
-        public Startup(IHostingEnvironment env)
+        public Startup(IWebHostEnvironment env)
         {
             _appConfiguration = env.GetAppConfiguration();
         }

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/AbpCompanyName.AbpProjectName.Web.Mvc.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/AbpCompanyName.AbpProjectName.Web.Mvc.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <AssemblyName>AbpCompanyName.AbpProjectName.Web.Mvc</AssemblyName>
@@ -7,7 +7,6 @@
     <UserSecretsId>AbpCompanyName-AbpProjectName-56C2EF2F-ABD6-4EFC-AAF2-2E81C34E8FB1</UserSecretsId>
     <RootNamespace>AbpCompanyName.AbpProjectName.Web</RootNamespace>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
@@ -15,7 +14,6 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <MvcRazorExcludeRefAssembliesFromPublish>false</MvcRazorExcludeRefAssembliesFromPublish>
     <PreserveCompilationReferences>true</PreserveCompilationReferences>
-    
   </PropertyGroup>
 
   <ItemGroup>
@@ -34,10 +32,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AbpCompanyName.AbpProjectName.Web.Core\AbpCompanyName.AbpProjectName.Web.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Resources/WebResourceManager.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Resources/WebResourceManager.cs
@@ -5,15 +5,16 @@ using Microsoft.AspNetCore.Mvc.Razor;
 using Abp.Collections.Extensions;
 using Abp.Extensions;
 using Abp.Timing;
+using Microsoft.Extensions.Hosting;
 
 namespace AbpCompanyName.AbpProjectName.Web.Resources
 {
     public class WebResourceManager : IWebResourceManager
     {
-        private readonly IHostingEnvironment _environment;
+        private readonly IWebHostEnvironment _environment;
         private readonly List<string> _scriptUrls;
 
-        public WebResourceManager(IHostingEnvironment environment)
+        public WebResourceManager(IWebHostEnvironment environment)
         {
             _environment = environment;
             _scriptUrls = new List<string>();

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Startup/AbpProjectNameWebMvcModule.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Startup/AbpProjectNameWebMvcModule.cs
@@ -9,10 +9,10 @@ namespace AbpCompanyName.AbpProjectName.Web.Startup
     [DependsOn(typeof(AbpProjectNameWebCoreModule))]
     public class AbpProjectNameWebMvcModule : AbpModule
     {
-        private readonly IHostingEnvironment _env;
+        private readonly IWebHostEnvironment _env;
         private readonly IConfigurationRoot _appConfiguration;
 
-        public AbpProjectNameWebMvcModule(IHostingEnvironment env)
+        public AbpProjectNameWebMvcModule(IWebHostEnvironment env)
         {
             _env = env;
             _appConfiguration = env.GetAppConfiguration();

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Startup/Startup.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Startup/Startup.cs
@@ -16,7 +16,7 @@ using AbpCompanyName.AbpProjectName.Web.Resources;
 using Abp.AspNetCore.SignalR.Hubs;
 using Abp.Dependency;
 using Abp.Json;
-using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json.Serialization;
 
 
@@ -26,7 +26,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Startup
     {
         private readonly IConfigurationRoot _appConfiguration;
 
-        public Startup(IHostingEnvironment env)
+        public Startup(IWebHostEnvironment env)
         {
             _appConfiguration = env.GetAppConfiguration();
         }
@@ -48,9 +48,6 @@ namespace AbpCompanyName.AbpProjectName.Web.Startup
                 };
             });
 
-            services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-                .AddCookie();
-
             IdentityRegistrar.Register(services);
             AuthConfigurer.Configure(services, _appConfiguration);
 
@@ -67,7 +64,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Startup
             );
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
             app.UseAbp(); // Initializes ABP framework.
 


### PR DESCRIPTION
- Replace `IHostingEnvironment` with `IWebHostEnvironment`(This type is obsolete and will be removed in a future version. The recommended alternative is `Microsoft.AspNetCore.Hosting.IWebHostEnvironment`) .
- `InProcess` already the default hosting mode.
- Remove `<FrameworkReference Include="Microsoft.AspNetCore.App" />` in `csproj` 
https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#implicit-package-references