### PR TITLE
Update dependencies to satisfy peer dependencies for Angular project

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -34,7 +34,7 @@
     "@types/moment-timezone": "^0.5.12",
     "@types/toastr": "^2.1.33",
     "abp-ng2-module": "^4.0.0",
-    "abp-web-resources": "^3.8.2",
+    "abp-web-resources": "^3.8.4",
     "animate.css": "^3.5.2",
     "block-ui": "^2.70.1",
     "bootstrap": "^3.3.7",
@@ -60,14 +60,14 @@
     "node-waves": "^0.7.5",
     "push.js": "1.0.9",
     "raphael": "^2.2.7",
-    "rxjs": "^6.2.0",
+    "rxjs": "^6.4.0",
     "simple-line-icons": "^2.4.1",
     "spin.js": "^2.3.2",
     "sweetalert": "^2.0.8",
     "toastr": "^2.1.2",
     "ts-helpers": "^1.1.2",
     "web-animations-js": "^2.3.2",
-    "zone.js": "~0.10.2"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.803.2",


### PR DESCRIPTION
Warnings when running `yarn` command before the change proposed in this PR:

```
warning " > @angular/common@8.2.4" has incorrect peer dependency "rxjs@^6.4.0".
warning " > @angular/core@8.2.4" has incorrect peer dependency "rxjs@^6.4.0".
warning " > @angular/core@8.2.4" has incorrect peer dependency "zone.js@~0.9.1".
warning " > @angular/forms@8.2.4" has incorrect peer dependency "rxjs@^6.4.0".
warning " > @angular/router@8.2.4" has incorrect peer dependency "rxjs@^6.4.0".
warning " > abp-ng2-module@4.0.0" has incorrect peer dependency "abp-web-resources@^3.8.4".
```