### PR TITLE
Fix error on signalR connection

### DIFF
--- a/reactjs/src/lib/signalRAspNetCoreHelper.ts
+++ b/reactjs/src/lib/signalRAspNetCoreHelper.ts
@@ -12,7 +12,8 @@ class SignalRAspNetCoreHelper {
       connect: undefined,
       hubs: undefined,
       qs: AppConsts.authorization.encrptedAuthTokenName + '=' + encodeURIComponent(encryptedAuthToken),
-      url: AppConsts.remoteServiceBaseUrl + '/signalr',
+      remoteServiceBaseUrl: AppConsts.remoteServiceBaseUrl,
+      url: '/signalr'
     };
 
     Util.loadScript(AppConsts.appBaseUrl + '/dist/abp.signalr-client.js');

--- a/vue/src/lib/SignalRAspNetCoreHelper.ts
+++ b/vue/src/lib/SignalRAspNetCoreHelper.ts
@@ -3,13 +3,14 @@ import Util from './util'
 class SignalRAspNetCoreHelper {
     initSignalR() {
         var encryptedAuthToken = Util.abp.utils.getCookieValue(AppConsts.authorization.encrptedAuthTokenName);
+        let remoteServerUrl = AppConsts.remoteServiceBaseUrl;
         Util.abp.signalr = {
             autoConnect: true,
             connect: undefined,
             hubs: undefined,
             qs: AppConsts.authorization.encrptedAuthTokenName + "=" + encodeURIComponent(encryptedAuthToken),
-            remoteServiceBaseUrl: AppConsts.remoteServiceBaseUrl,
-            url: 'signalr'
+            remoteServiceBaseUrl: remoteServerUrl.endsWith('/') ? remoteServerUrl.slice(0, -1) : remoteServerUrl,
+            url: '/signalr'
         };
 
         Util.loadScript(AppConsts.appBaseUrl + '/dist/abp.signalr-client.js');

--- a/vue/src/lib/SignalRAspNetCoreHelper.ts
+++ b/vue/src/lib/SignalRAspNetCoreHelper.ts
@@ -3,13 +3,13 @@ import Util from './util'
 class SignalRAspNetCoreHelper {
     initSignalR() {
         var encryptedAuthToken = Util.abp.utils.getCookieValue(AppConsts.authorization.encrptedAuthTokenName);
-        let remoteServerUrl = AppConsts.remoteServiceBaseUrl;
         Util.abp.signalr = {
             autoConnect: true,
             connect: undefined,
             hubs: undefined,
             qs: AppConsts.authorization.encrptedAuthTokenName + "=" + encodeURIComponent(encryptedAuthToken),
-            remoteServiceBaseUrl: remoteServerUrl.endsWith('/') ? remoteServerUrl.slice(0, -1) : remoteServerUrl
+            remoteServiceBaseUrl: AppConsts.remoteServiceBaseUrl,
+            url: 'signalr'
         };
 
         Util.loadScript(AppConsts.appBaseUrl + '/dist/abp.signalr-client.js');

--- a/vue/src/lib/SignalRAspNetCoreHelper.ts
+++ b/vue/src/lib/SignalRAspNetCoreHelper.ts
@@ -3,13 +3,12 @@ import Util from './util'
 class SignalRAspNetCoreHelper {
     initSignalR() {
         var encryptedAuthToken = Util.abp.utils.getCookieValue(AppConsts.authorization.encrptedAuthTokenName);
-        let remoteServerUrl = AppConsts.remoteServiceBaseUrl;
         Util.abp.signalr = {
             autoConnect: true,
             connect: undefined,
             hubs: undefined,
             qs: AppConsts.authorization.encrptedAuthTokenName + "=" + encodeURIComponent(encryptedAuthToken),
-            remoteServiceBaseUrl: remoteServerUrl.endsWith('/') ? remoteServerUrl.slice(0, -1) : remoteServerUrl,
+            remoteServiceBaseUrl: AppConsts.remoteServiceBaseUrl,
             url: '/signalr'
         };
 

--- a/vue/src/lib/SignalRAspNetCoreHelper.ts
+++ b/vue/src/lib/SignalRAspNetCoreHelper.ts
@@ -1,9 +1,9 @@
 import AppConsts from './appconst'
 import Util from './util'
-class SignalRAspNetCoreHelper {
-    initSignalR() {
+class SignalRAspNetCoreHelper{
+    initSignalR(){
         var encryptedAuthToken = Util.abp.utils.getCookieValue(AppConsts.authorization.encrptedAuthTokenName);
-        
+
         Util.abp.signalr = {
             autoConnect: true,
             connect: undefined,

--- a/vue/src/lib/SignalRAspNetCoreHelper.ts
+++ b/vue/src/lib/SignalRAspNetCoreHelper.ts
@@ -1,15 +1,15 @@
 import AppConsts from './appconst'
 import Util from './util'
-class SignalRAspNetCoreHelper{
-    initSignalR(){
+class SignalRAspNetCoreHelper {
+    initSignalR() {
         var encryptedAuthToken = Util.abp.utils.getCookieValue(AppConsts.authorization.encrptedAuthTokenName);
-
+        let remoteServerUrl = AppConsts.remoteServiceBaseUrl;
         Util.abp.signalr = {
             autoConnect: true,
             connect: undefined,
             hubs: undefined,
             qs: AppConsts.authorization.encrptedAuthTokenName + "=" + encodeURIComponent(encryptedAuthToken),
-            url: AppConsts.remoteServiceBaseUrl + '/signalr'
+            remoteServiceBaseUrl: remoteServerUrl.endsWith('/') ? remoteServerUrl.slice(0, -1) : remoteServerUrl
         };
 
         Util.loadScript(AppConsts.appBaseUrl + '/dist/abp.signalr-client.js');

--- a/vue/src/lib/SignalRAspNetCoreHelper.ts
+++ b/vue/src/lib/SignalRAspNetCoreHelper.ts
@@ -3,6 +3,7 @@ import Util from './util'
 class SignalRAspNetCoreHelper {
     initSignalR() {
         var encryptedAuthToken = Util.abp.utils.getCookieValue(AppConsts.authorization.encrptedAuthTokenName);
+        
         Util.abp.signalr = {
             autoConnect: true,
             connect: undefined,

--- a/vue/src/lib/appconst.ts
+++ b/vue/src/lib/appconst.ts
@@ -1,15 +1,15 @@
 import url from './url'
-const AppConsts= {
-    userManagement:{
+const AppConsts = {
+    userManagement: {
         defaultAdminUserName: 'admin'
     },
-    localization:{
+    localization: {
         defaultLocalizationSourceName: 'AbpProjectName'
     },
-    authorization:{
+    authorization: {
         encrptedAuthTokenName: 'enc_auth_token'
     },
     appBaseUrl: "http://localhost:8080",
-    remoteServiceBaseUrl:url
+    remoteServiceBaseUrl: url.endsWith('/') ? url.slice(0, -1) : url
 }
 export default AppConsts

--- a/vue/src/lib/appconst.ts
+++ b/vue/src/lib/appconst.ts
@@ -1,12 +1,12 @@
 import url from './url'
-const AppConsts = {
-    userManagement: {
+const AppConsts= {
+    userManagement:{
         defaultAdminUserName: 'admin'
     },
-    localization: {
+    localization:{
         defaultLocalizationSourceName: 'AbpProjectName'
     },
-    authorization: {
+    authorization:{
         encrptedAuthTokenName: 'enc_auth_token'
     },
     appBaseUrl: "http://localhost:8080",


### PR DESCRIPTION
in `abp.signalr-client.js` ,there are two main fucntions  about signalR connection

https://github.com/aspnetboilerplate/aspnetboilerplate/blob/fc11d4ca6fc7044ad5ffce7fc18f5519e0ef71fd/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr-client.js#L64

and 

https://github.com/aspnetboilerplate/aspnetboilerplate/blob/fc11d4ca6fc7044ad5ffce7fc18f5519e0ef71fd/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr-client.js#L86

if the `remoteServiceBaseUrl` is null or '',  i got this 404 error

![image](https://user-images.githubusercontent.com/10289019/71444271-f5048a00-274a-11ea-82af-aea5ae14e128.png)

apart from this，when is use this:
```js
 Util.abp.signalr.startConnection("/signalr-testHub", function(connection) {})
```
i also get 404 error,it will connect to a client url not a server url,no matter i put `signalr-testHub` or  `/signalr-testHub`

i must set an absolute remote server hub url.

set `remoteServiceBaseUrl` would be better.



