### PR TITLE
Order user menu items by order and display name

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Shared/Components/SideBarMenu/Default.cshtml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Shared/Components/SideBarMenu/Default.cshtml
@@ -1,9 +1,13 @@
 ﻿@using AbpCompanyName.AbpProjectName.Web.Views.Shared.Components.SideBarMenu
 @model SideBarMenuViewModel
+@{ 
+    var orderedMenuItems = Model.MainMenu.Items.Where(x => x.IsVisible).OrderByCustom().ToList();
+}
+
 <nav class="mt-2">
     <ul class="nav nav-pills nav-sidebar flex-column nav-flat" data-widget="treeview" role="menu" data-accordion="false">
         @{
-            foreach (var item in Model.MainMenu.Items.Where(x => x.IsVisible))
+            foreach (var item in orderedMenuItems)
             {
                 @await Html.PartialAsync("Components/SideBarMenu/_MenuItem", item)
             }

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Shared/Components/SideBarMenu/UserMenuItemExtensions.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Shared/Components/SideBarMenu/UserMenuItemExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Abp.Application.Navigation;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AbpCompanyName.AbpProjectName.Web.Views.Shared.Components.SideBarMenu
+{
+    public static class UserMenuItemExtensions
+    {
+        public static IOrderedEnumerable<UserMenuItem> OrderByCustom(this IEnumerable<UserMenuItem> menuItems)
+        {
+            return menuItems
+                .OrderBy(menuItem => menuItem.Order)
+                .ThenBy(menuItem => menuItem.DisplayName);
+        }
+    }
+}

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Shared/Components/SideBarMenu/_MenuItem.cshtml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Shared/Components/SideBarMenu/_MenuItem.cshtml
@@ -1,10 +1,11 @@
 ﻿@using AbpCompanyName.AbpProjectName.Web.Views
+@using AbpCompanyName.AbpProjectName.Web.Views.Shared.Components.SideBarMenu
 @using Abp.Application.Navigation
 @model Abp.Application.Navigation.UserMenuItem
 @inject ILanguageManager LanguageManager
 @{
     var isActive = IsActiveMenuItem(Model, ViewBag.CurrentPageName);
-    var subMenus = Model.Items.Where(x => x.IsVisible).ToList();
+    var subMenus = Model.Items.Where(x => x.IsVisible).OrderByCustom().ToList();
     var hasSubMenus = subMenus.Any();
 }
 @functions {


### PR DESCRIPTION
Added an extension method in `Web.Mvc` project to easily change the ordering across the project.

```c#
public static IOrderedEnumerable<UserMenuItem> OrderByCustom(this IEnumerable<UserMenuItem> menuItems)
{
    return menuItems
        .OrderBy(menuItem => menuItem.Order)
        .ThenBy(menuItem => menuItem.DisplayName);
}
```

Related: [https://stackoverflow.com/questions/60318625/menuitemdefinition-order](https://stackoverflow.com/q/60318625/8601760) (v4.x template)