### PR TITLE
Fix moment package version

### DIFF
--- a/reactjs/package.json
+++ b/reactjs/package.json
@@ -14,7 +14,7 @@
     "lodash": "^4.17.15",
     "mobx": "^5.15.0",
     "mobx-react": "^6.1.4",
-    "moment": "^2.24.0",
+    "moment": "2.24.0",
     "moment-timezone": "^0.5.27",
     "query-string": "^6.9.0",
     "react": "^16.12.0",


### PR DESCRIPTION
Error before: Attempted import error: 'locale' is not exported from 'moment' (imported as 'moment').