### PR TITLE
Revert "Include query string in return url for link to change culture"

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Shared/Components/AccountLanguages/Default.cshtml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Shared/Components/AccountLanguages/Default.cshtml
@@ -1,17 +1,14 @@
-﻿@using System.Web
+﻿@using System.Text.Encodings.Web
 @using AbpCompanyName.AbpProjectName.Web.Views.Shared.Components.AccountLanguages
 @model LanguageSelectionViewModel
 @if (Model.Languages.Count > 1)
 {
     <div class="text-center">
-        @foreach (var languageInfo in Model.Languages)
+        @foreach (var language in Model.Languages)
         {
-            <a href="@Url.Action("ChangeCulture", "AbpLocalization", new {
-                    cultureName = languageInfo.Name,
-                    returnUrl = HttpUtility.UrlEncode(Context.Request.Path + Context.Request.QueryString)
-                })">
-                <span class="@(languageInfo.Name == Model.CurrentLanguage.Name ? "current-language-icon" : "")" title="@languageInfo.DisplayName">
-                    <i class="@languageInfo.Icon"></i>
+            <a href="~/AbpLocalization/ChangeCulture?cultureName=@(language.Name)&returnUrl=@(UrlEncoder.Default.Encode(Context.Request.Path + Context.Request.QueryString))">
+                <span class="@(language.Name == Model.CurrentLanguage.Name ? "current-language-icon" : "")" title="@language.DisplayName">
+                    <i class="@language.Icon"></i>
                 </span>
             </a>
         }

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Shared/Components/RightNavbarLanguageSwitch/Default.cshtml
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Views/Shared/Components/RightNavbarLanguageSwitch/Default.cshtml
@@ -1,5 +1,4 @@
-﻿@using System.Web
-@using AbpCompanyName.AbpProjectName.Web.Views.Shared.Components.RightNavbarLanguageSwitch
+﻿@using AbpCompanyName.AbpProjectName.Web.Views.Shared.Components.RightNavbarLanguageSwitch
 @model RightNavbarLanguageSwitchViewModel
 
 <li class="nav-item dropdown">
@@ -8,15 +7,12 @@
         <span class="d-none d-md-inline-block">@Model.CurrentLanguage.DisplayName</span>
     </a>
     <div class="dropdown-menu dropdown-menu-right p-0">
-        @foreach (var languageInfo in Model.Languages)
+        @foreach (var language in Model.Languages)
         {
-            if (languageInfo.Name != Model.CurrentLanguage.Name)
+            if (language.Name != Model.CurrentLanguage.Name)
             {
-                <a class="dropdown-item" href="@Url.Action("ChangeCulture", "AbpLocalization", new {
-                                                  cultureName = languageInfo.Name,
-                                                  returnUrl = HttpUtility.UrlEncode(Context.Request.Path + Context.Request.QueryString)
-                                              })">
-                    <i class="mr-2 @languageInfo.Icon"></i> @languageInfo.DisplayName
+                <a class="dropdown-item" href="@(ApplicationPath)AbpLocalization/ChangeCulture?cultureName=@(language.Name)&returnUrl=@(Context.Request.Path)">
+                    <i class="mr-2 @language.Icon"></i> @language.DisplayName
                 </a>
             }
         }


### PR DESCRIPTION
Reverts aspnetboilerplate/module-zero-core-template#537


`@Url.Action()` seems to escape the route params and causing double encoding with `HttpUtility.UrlEncode()`