### PR TITLE
Setup ESLint for reactjs project

### DIFF
--- a/reactjs/.eslintrc.js
+++ b/reactjs/.eslintrc.js
@@ -1,0 +1,37 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  extends: [
+    'airbnb-typescript',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:jsx-a11y/recommended',
+    'plugin:jest/recommended',
+    'prettier/@typescript-eslint',
+    'prettier',
+  ],
+  plugins: ['react-hooks'],
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    project: './tsconfig.json',
+  },
+  rules: {
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
+    'react/prop-types': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    curly: 'error',
+    '@typescript-eslint/no-unused-vars': 'warn', // Imports of interfaces throw this.
+    'react/jsx-one-expression-per-line': 0,
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  ignorePatterns: ['node_modules/', 'src/registerServiceWorker.ts'],
+};

--- a/reactjs/.prettierrc
+++ b/reactjs/.prettierrc
@@ -1,11 +1,13 @@
 {
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "printWidth": 150,
-    "overrides": [{
-        "files": ".prettierrc",
-        "options": {
-            "parser": "json"
-        }
-    }]
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "overrides": [
+    {
+      "files": ".prettierrc",
+      "options": {
+        "parser": "json"
+      }
+    }
+  ]
 }

--- a/reactjs/package.json
+++ b/reactjs/package.json
@@ -25,9 +25,13 @@
     "react-scripts": "^3.2.0",
     "recharts": "^1.8.5"
   },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
   "scripts": {
     "start": "craco start",
     "build": "craco build",
+    "lint": "eslint . --ext .ts,.tsx",
     "test": "craco test",
     "eject": "react-scripts eject"
   },
@@ -43,7 +47,19 @@
     "@types/react-loadable": "^5.5.2",
     "@types/react-router-dom": "^5.1.3",
     "@types/recharts": "^1.8.3",
+    "@typescript-eslint/eslint-plugin": "^4.0.1",
+    "@typescript-eslint/parser": "^4.0.1",
     "copy-webpack-plugin": "^5.0.5",
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb-typescript": "^9.0.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-jest": "^23.17.1",
+    "eslint-plugin-jsx-a11y": "^6.3.1",
+    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-react": "^7.20.6",
+    "eslint-plugin-react-hooks": "^4.1.0",
+    "prettier": "^2.0.5",
     "ts-import-plugin": "^1.6.1",
     "typescript": "^3.7.2"
   },


### PR DESCRIPTION
Added ESLint config with the following plugins / extensions:
 - Airbnb-typescript style guide
 - A11y accessibility
 - Jest
 - Prettier

Reduced line width in prettier config to 100 characters.