### PR TITLE
Optimize project references

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Application/Users/UserAppService.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Application/Users/UserAppService.cs
@@ -21,7 +21,6 @@ using AbpCompanyName.AbpProjectName.Authorization.Users;
 using AbpCompanyName.AbpProjectName.Roles.Dto;
 using AbpCompanyName.AbpProjectName.Users.Dto;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
 
 namespace AbpCompanyName.AbpProjectName.Users
 {
@@ -167,7 +166,7 @@ namespace AbpCompanyName.AbpProjectName.Users
 
         protected override async Task<User> GetEntityByIdAsync(long id)
         {
-            var user = await Repository.GetAllIncluding(x => x.Roles).FirstOrDefaultAsync(x => x.Id == id);
+            var user = await AsyncQueryableExecuter.FirstOrDefaultAsync(Repository.GetAllIncluding(x => x.Roles).Where(x => x.Id == id));
 
             if (user == null)
             {

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/AbpCompanyName.AbpProjectName.Core.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/AbpCompanyName.AbpProjectName.Core.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Abp.AutoMapper" Version="6.5.0" />
-    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="6.5.0" />
+    <PackageReference Include="Abp.ZeroCore" Version="6.5.0" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.4.0" />
   </ItemGroup>
 

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.EntityFrameworkCore/AbpCompanyName.AbpProjectName.EntityFrameworkCore.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.EntityFrameworkCore/AbpCompanyName.AbpProjectName.EntityFrameworkCore.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="6.5.0" />
+    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="7.1.0" />
   </ItemGroup>
    
   <ItemGroup>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.EntityFrameworkCore/AbpCompanyName.AbpProjectName.EntityFrameworkCore.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.EntityFrameworkCore/AbpCompanyName.AbpProjectName.EntityFrameworkCore.csproj
@@ -26,6 +26,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="6.5.0" />
+  </ItemGroup>
    
   <ItemGroup>
     <ProjectReference Include="..\AbpCompanyName.AbpProjectName.Core\AbpCompanyName.AbpProjectName.Core.csproj" />

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/AbpCompanyName.AbpProjectName.Migrator.csproj
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Migrator/AbpCompanyName.AbpProjectName.Migrator.csproj
@@ -22,7 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AbpCompanyName.AbpProjectName.Core\AbpCompanyName.AbpProjectName.Core.csproj" />
     <ProjectReference Include="..\AbpCompanyName.AbpProjectName.EntityFrameworkCore\AbpCompanyName.AbpProjectName.EntityFrameworkCore.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
for best practices, `core` and `application` projects not depend with `EntityFramework` 