### PR TITLE
fix 'secrets.json' was not found

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Configuration/AppConfigurations.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Configuration/AppConfigurations.cs
@@ -38,7 +38,7 @@ namespace AbpCompanyName.AbpProjectName.Configuration
 
             if (addUserSecrets)
             {
-                builder.AddUserSecrets(typeof(AppConfigurations).GetAssembly());
+                builder.AddUserSecrets(typeof(AppConfigurations).GetAssembly(), optional: true);
             }
 
             return builder.Build();


### PR DESCRIPTION
while running on .net6, it will occure an error:
> Unhandled exception. System.IO.FileNotFoundException: The configuration file 'secrets.json' was not found and is not optional. 