### PR TITLE
Update Dockerfile

### DIFF
--- a/angular/Dockerfile
+++ b/angular/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1
-FROM node:14 as node
+FROM node:20 as node
 WORKDIR /app
 COPY . .
 # This is a workaround to avoid updating appconfig.production.json file. 


### PR DESCRIPTION
angular17 incompatible with node 14, got error of "88.21 error @angular/animations@17.0.5: The engine "node" is incompatible with this module. Expected version "^18.13.0 || >=20.9.0". Got "14.21.3"" when run docker build.