### PR TITLE
Update ngx-bootstrap to solve compatibility problem with Angular 17

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -31,7 +31,7 @@
     "lodash-es": "^4.17.15",
     "moment": "2.29.4",
     "moment-timezone": "0.5.43",
-    "ngx-bootstrap": "^11.0.2",
+    "ngx-bootstrap": "^12.0.0",
     "ngx-pagination": "^6.0.3",
     "push.js": "1.0.12",
     "rxjs": "^7.8.1",


### PR DESCRIPTION
According to the ngx-bootstrap version compatibility list the version 12.x.x is the compatible one with Angular 17.
[https://github.com/valor-software/ngx-bootstrap?tab=readme-ov-file#compatibility](https://github.com/valor-software/ngx-bootstrap?tab=readme-ov-file#compatibility)