### PR TITLE
Removed AddRazorRuntimeCompilation from Startup

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Startup/Startup.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Startup/Startup.cs
@@ -40,8 +40,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Startup
                         options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
                         options.Filters.Add(new AbpAutoValidateAntiforgeryTokenAttribute());
                     }
-                )
-                .AddRazorRuntimeCompilation();
+                );
 
             IdentityRegistrar.Register(services);
             AuthConfigurer.Configure(services, _appConfiguration);


### PR DESCRIPTION
Resolves [aspnetboilerplate/issues/6971](https://github.com/aspnetboilerplate/aspnetboilerplate/issues/6971)

AddRazorRuntimeCompilation has been removed from startup.cs. The reason why it is removed here is at run time and if they want to add a unique CSS, which is the best thing, there is a high probability that the CSS changes will not appear at run time. For this reason, AddRazorRuntimeCompilation has been removed. According to the recommendations in the Microsoft documentation, it is recommended to use hot reload in order to see the changes in the development environment. It is written in the [document ](https://learn.microsoft.com/en-us/aspnet/core/mvc/views/view-compilation?view=aspnetcore-8.0&tabs=visual-studio)that AddRazorRuntimeCompilation disables hot reload.