### PR TITLE
Fix bug on create component

### DIFF
--- a/angular/angular.json
+++ b/angular/angular.json
@@ -177,7 +177,8 @@
   "schematics": {
     "@schematics/angular:component": {
       "prefix": "app",
-      "style": "css"
+      "style": "css",
+      "project": "AbpProjectName"
     },
     "@schematics/angular:directive": {
       "prefix": "app"


### PR DESCRIPTION
When I tried to create a component, this error ocurred: 
![image](https://github.com/user-attachments/assets/8a6468bd-b4ad-4511-971a-6bb1f76beba9)

I added the project name into schematics in angular.json and the bug disappeared.
Reference: https://github.com/angular/angular-cli/issues/25402#issuecomment-2063914916