### PR TITLE
Hided .swal2-title elements by changing display to none

### DIFF
--- a/angular/src/shared/core.less
+++ b/angular/src/shared/core.less
@@ -22,7 +22,7 @@
 }
 
 /* Sweet alert */
-.swal2-title {
+.swal2-title:empty {
   display: none !important;
 }
 

--- a/angular/src/shared/core.less
+++ b/angular/src/shared/core.less
@@ -23,7 +23,7 @@
 
 /* Sweet alert */
 .swal2-title {
-  display: inline-block !important;
+  display: none !important;
 }
 
 body.swal2-height-auto {


### PR DESCRIPTION
[Resolves aspnetboilerplate/issues/6994](https://github.com/aspnetboilerplate/aspnetboilerplate/issues/6994)

Toast notification title space has been removed