### PR TITLE
Updated launchSettings.json

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Properties/launchSettings.json
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Properties/launchSettings.json
@@ -18,11 +18,10 @@
     "AbpCompanyName.AbpProjectName.Web.Host": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "https://localhost:44311/",
+      "applicationUrl": "https://localhost:44311/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:44311/"
+      }
     }
   }
 }

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Properties/launchSettings.json
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     "AbpCompanyName.AbpProjectName.Web": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "https://localhost:44312",
+      "applicationUrl": "https://localhost:44312",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
Updated launchSettings.json to use applicationUrl instead of launchUrl.
This will allow the project to be run as a launch profile instead of the IIS Express profile.
Otherwise when running the project with the project profile, the web browser opens but does not connect to the website.

Fixes issue https://github.com/aspnetboilerplate/aspnetboilerplate/issues/7052