### PR TITLE
Add items added to style.css that are missing during compilation to custom.scss

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/wwwroot/scss/_custom.scss
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/wwwroot/scss/_custom.scss
@@ -25,3 +25,21 @@ html {
   margin-right: 4px;
   margin-top: -4px;
 }
+
+.famfamfam-flags {
+    display: inline-block;
+}
+
+.sidebar ul li p {
+    white-space: nowrap !important;
+    text-overflow: ellipsis;
+    transition: opacity 0.5s ease-in-out !important;
+    opacity: 1;
+}
+
+.sidebar-mini .main-sidebar .sidebar,
+.sidebar-mini .main-sidebar .sidebar:hover {
+    overflow-x: auto !important;
+    width: 250px;
+    transition: width 0.3s ease-in-out;
+}


### PR DESCRIPTION
Flags and some styles are added only to css, so when compiling scss, the flags are not rendered and disappear.
```
.famfamfam-flags {
    display: inline-block;
}

.sidebar ul li p {
    white-space: nowrap !important;
    text-overflow: ellipsis;
    transition: opacity 0.5s ease-in-out !important;
    opacity: 1;
}

.sidebar-mini .main-sidebar .sidebar,
.sidebar-mini .main-sidebar .sidebar:hover {
    overflow-x: auto !important;
    width: 250px;
    transition: width 0.3s ease-in-out;
}
```
I copy it to _custom.scss so it won't be missed during compilation.
