### PR TITLE
Fixed an issue where the Role.Description property would cause the error "SqlNullValueException: Data is Null."

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Authorization/Roles/Role.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Authorization/Roles/Role.cs
@@ -23,5 +23,5 @@ public class Role : AbpRole<User>
     }
 
     [StringLength(MaxDescriptionLength)]
-    public string Description { get; set; }
+    public string? Description { get; set; }
 }


### PR DESCRIPTION
Fixed an small issue where the Role.Description property would cause the error "SqlNullValueException: Data is Null. This method or property cannot be called on Null values." when the project was set to nullable is enabled.
But finding the cause takes a lot of time. This will save you time.